### PR TITLE
fix: avoid CCSwitch config restore conflicts

### DIFF
--- a/.github/workflows/sync-star-history.yml
+++ b/.github/workflows/sync-star-history.yml
@@ -1,5 +1,8 @@
+# Render the official-style Star History charts locally from upstream source, then publish
+# the bilingual README site through Pages without creating chart-update commits.
 name: Deploy README and Star History
 
+# README/image changes deploy immediately; the schedule refreshes star data every 12 hours.
 on:
   push:
     branches:
@@ -14,12 +17,14 @@ on:
     - cron: "23 */12 * * *"
   workflow_dispatch:
 
+# Pages deployment and old deployment-record cleanup require these narrowly scoped permissions.
 permissions:
   contents: read
   deployments: write
   pages: write
   id-token: write
 
+# A newer refresh supersedes an older in-progress render.
 concurrency:
   group: star-history-pages
   cancel-in-progress: true
@@ -43,6 +48,7 @@ jobs:
       - name: Check out this repository
         uses: actions/checkout@v4
 
+      # Use the upstream renderer directly instead of the unstable hosted chart endpoint.
       - name: Check out official Star History source
         uses: actions/checkout@v4
         with:
@@ -94,6 +100,7 @@ jobs:
           umask 077
           printf '%s' "${GITHUB_API_TOKEN}" > "${token_file}"
 
+          # Make upstream token validation target this repository rather than the upstream repo.
           token_source="${STAR_HISTORY_SOURCE_DIR}/backend/token.ts"
           python3 - "${token_source}" <<'PY'
           from pathlib import Path
@@ -111,6 +118,7 @@ jobs:
           path.write_text(source.replace(original, replacement))
           PY
 
+          # Always stop the local backend and remove the temporary token file.
           cleanup() {
             if [[ -n "${server_pid:-}" ]]; then
               kill "${server_pid}" 2>/dev/null || true
@@ -128,6 +136,7 @@ jobs:
           ) >"${server_log}" 2>&1 &
           server_pid=$!
 
+          # Wait for the runner-local renderer; no api.star-history.com/chart call is used.
           for attempt in {1..60}; do
             if curl --fail --silent http://127.0.0.1:8080/healthz >/dev/null; then
               break
@@ -156,6 +165,7 @@ jobs:
             --pages-url "${STAR_HISTORY_PAGES_URL}" \
             --output-dir "${STAR_HISTORY_SITE_DIR}"
 
+          # Skip Pages deployment when the rendered manifest matches the deployed site.
           current_dir="$(mktemp -d)"
           changed=true
           if curl --fail --silent --location \
@@ -184,6 +194,7 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v5
 
+      # Keep the newest Pages deployment record and remove superseded records from GitHub.
       - name: Delete old GitHub Pages deployment records
         if: ${{ success() && steps.render.outcome == 'success' }}
         uses: actions/github-script@v9

--- a/.github/workflows/test-codex-instruct.yml
+++ b/.github/workflows/test-codex-instruct.yml
@@ -1,0 +1,45 @@
+name: Test codex-instruct
+
+on:
+  pull_request:
+    paths:
+      - "codex-instruct.py"
+      - "unit_tests/**"
+      - ".github/workflows/test-codex-instruct.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "codex-instruct.py"
+      - "unit_tests/**"
+      - ".github/workflows/test-codex-instruct.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test compatibility dependency
+        run: python -m pip install tomli
+
+      - name: Compile deployment script and tests
+        run: python -m py_compile codex-instruct.py unit_tests/test_codex_instruct.py
+
+      - name: Run unit tests
+        run: python -m unittest discover -s unit_tests -q

--- a/.github/workflows/test-codex-instruct.yml
+++ b/.github/workflows/test-codex-instruct.yml
@@ -1,5 +1,8 @@
+# Validate deployment and rollback behavior on the oldest and newest supported Python releases.
+# The tests use temporary CODEX_HOME directories and never touch a runner user configuration.
 name: Test codex-instruct
 
+# Run only when the deployment script, its tests, or this workflow changes.
 on:
   pull_request:
     paths:
@@ -15,12 +18,14 @@ on:
       - ".github/workflows/test-codex-instruct.yml"
   workflow_dispatch:
 
+# The test job only needs to read the checked-out repository.
 permissions:
   contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Keep both matrix jobs running so a compatibility failure is visible independently.
     strategy:
       fail-fast: false
       matrix:
@@ -35,11 +40,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Python 3.8-3.10 use tomli; newer Python versions use the standard-library tomllib.
       - name: Install test compatibility dependency
         run: python -m pip install tomli
 
+      # Catch syntax/import compatibility problems before running behavioral tests.
       - name: Compile deployment script and tests
         run: python -m py_compile codex-instruct.py unit_tests/test_codex_instruct.py
 
+      # Exercise config ownership, safe reset, snapshot recovery, and file-preservation cases.
       - name: Run unit tests
         run: python -m unittest discover -s unit_tests -q

--- a/README.md
+++ b/README.md
@@ -122,23 +122,36 @@ python3 codex-instruct.py --version v5 --codex-dir ~/.codex
 # 部署自定义 ZIP 或 Markdown
 python3 codex-instruct.py --file ./custom-instructions.zip
 
-# 从备份恢复
+# 安全卸载提示词；只恢复本项目管理的配置项
 python3 codex-instruct.py --reset
+
+# 人工应急：显式恢复整份 config.toml 快照
+python3 codex-instruct.py \
+  --restore-snapshot ~/.codex/config.toml.bak_YYYYMMDD_HHMMSS_ffffff \
+  --codex-dir ~/.codex
 ```
 
 </details>
 
-执行 `--reset` 时，脚本会列出可用备份并要求二次确认，随后恢复配置并清理脚本管理的指令文件。
+执行 `--reset` 时，脚本只恢复部署前的顶层 `model_instructions_file`，不会用旧快照覆盖整个 `config.toml`。脚本仅删除由本次状态记录为新建且 SHA256 未变化的提示词；部署前已存在或后来被用户修改的文件会保留。
 
 ### 手动部署及回滚
 
-解压所选版本，将指令文件复制到 `CODEX_HOME`，备份 `config.toml`，并写入：
+解压所选版本，将指令文件复制到 `CODEX_HOME`，为 `config.toml` 创建操作前快照，并写入：
 
 ```toml
 model_instructions_file = "./gpt-5.6-sol-unrestricted-v5.md"
 ```
 
-若要手动回滚，直接删除或用`#`注释掉上述行即可恢复模型原始默认行为；可选择手动删除 `gpt-5.6-sol-unrestricted-v5.md` 或 `gpt-5.6-sol-unrestricted-v35.md`，以清理本地文件。
+若要手动回滚，直接删除或用 `#` 注释掉上述行即可恢复模型原始默认行为；可选择手动删除 `gpt-5.6-sol-unrestricted-v5.md` 或 `gpt-5.6-sol-unrestricted-v35.md`，以清理本地文件。
+
+### CCSwitch 兼容性
+
+- 部署前的指令项、已部署文件 SHA256 及部署前是否存在记录在 `CODEX_HOME/.gpt56-sol-instruct-state.json`；状态文件不保存 provider、模型、URL 或认证数据。
+- CCSwitch 在部署后写入的 provider、模型和认证配置会在 `--reset` 后保留。
+- 完整 `config.toml.bak_<时间戳>` 快照只用于人工应急恢复；需要恢复整份配置时，必须显式使用 `--restore-snapshot` 并再次确认。
+- 旧版 `config.toml.gpt56-sol-instruct.bak` 只用于找回原有 `model_instructions_file`，其中的其他配置不会自动写回。
+- 已存在且未被状态文件接管的 Markdown 文件不会被覆盖；请使用其他 `--name`。
 
 <a id="results"></a>
 
@@ -183,6 +196,8 @@ gpt-5.6-instruct/
 ├── gpt-5.6-sol-unrestricted-v5.zip    # v5 发布包
 ├── gpt-5.6-sol-unrestricted-v35.zip   # v35 发布包
 ├── scripts/*.zip                      # 可复现评测工具
+├── unit_tests/test_codex_instruct.py  # 部署与回滚单元测试
+├── .github/workflows/test-codex-instruct.yml # Python 3.8/3.13 CI
 └── docs/                              # 中英文对比文档、评测说明与图片
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -122,23 +122,36 @@ python3 codex-instruct.py --version v5 --codex-dir ~/.codex
 # Deploy a custom ZIP or Markdown file
 python3 codex-instruct.py --file ./custom-instructions.zip
 
-# Restore from a backup
+# Safely uninstall the prompt; restore only project-managed settings
 python3 codex-instruct.py --reset
+
+# Manual emergency recovery: explicitly restore a full config.toml snapshot
+python3 codex-instruct.py \
+  --restore-snapshot ~/.codex/config.toml.bak_YYYYMMDD_HHMMSS_ffffff \
+  --codex-dir ~/.codex
 ```
 
 </details>
 
-With `--reset`, the script lists available backups and asks for confirmation before restoring the configuration and removing managed instruction files.
+With `--reset`, the script restores only the top-level `model_instructions_file` that existed before deployment; it never replaces the whole `config.toml` with an old snapshot. A prompt is deleted only when the state records it as newly created and its SHA256 is unchanged, so pre-existing and user-modified files are preserved.
 
 ### Manual Deployment and Rollback
 
-Extract the selected version, copy the instruction file to `CODEX_HOME`, back up `config.toml`, and add:
+Extract the selected version, copy the instruction file to `CODEX_HOME`, create a pre-operation snapshot of `config.toml`, and add:
 
 ```toml
 model_instructions_file = "./gpt-5.6-sol-unrestricted-v5.md"
 ```
 
 To roll back manually, delete or comment out the line above with `#` to restore the model's original default behavior. You can also delete `gpt-5.6-sol-unrestricted-v5.md` or `gpt-5.6-sol-unrestricted-v35.md` to clean up the local files.
+
+### CCSwitch compatibility
+
+- The previous instruction entry, deployed-file SHA256 values, and whether each file existed before deployment are stored in `CODEX_HOME/.gpt56-sol-instruct-state.json`. Provider, model, URL, and authentication data are not stored there.
+- Provider, model, and authentication changes made by CCSwitch after deployment survive `--reset`.
+- Full `config.toml.bak_<timestamp>` snapshots are for manual emergency recovery only. Restoring the whole configuration requires an explicit `--restore-snapshot` command and confirmation.
+- A legacy `config.toml.gpt56-sol-instruct.bak` is consulted only for the previous `model_instructions_file`; its other settings are never restored automatically.
+- An existing Markdown file not already tracked by the state file is never overwritten; choose another `--name`.
 
 <a id="results"></a>
 
@@ -183,6 +196,8 @@ gpt-5.6-instruct/
 ├── gpt-5.6-sol-unrestricted-v5.zip    # v5 release archive
 ├── gpt-5.6-sol-unrestricted-v35.zip   # v35 release archive
 ├── scripts/*.zip                      # Reproducible evaluation tools
+├── unit_tests/test_codex_instruct.py  # Deployment and rollback unit tests
+├── .github/workflows/test-codex-instruct.yml # Python 3.8/3.13 CI
 └── docs/                              # Bilingual comparisons, methodology, and images
 ```
 

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -2,15 +2,16 @@
 """Select, deploy, or remove a gpt-5.6-sol Codex instruction file.
 
 The public repository stores each prompt as a ZIP archive. Applying a version
-extracts its Markdown file into CODEX_HOME, backs up config.toml, and sets the
-top-level `model_instructions_file` entry. The interactive reset action lists
-available backups, restores the user-selected file after confirmation, and
-removes prompt files managed by this script.
+extracts its Markdown file into CODEX_HOME, snapshots config.toml, and sets the
+top-level `model_instructions_file` entry. Reset only restores that managed
+entry and removes prompt files owned by this script; it never replaces the
+whole config.toml, so provider managers such as CCSwitch remain authoritative.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import shutil
@@ -36,6 +37,8 @@ MANAGED_PROMPT_FILENAMES = {
     *(choice["md_filename"] for choice in PROMPT_VERSIONS.values()),
 }
 BASELINE_BACKUP_SUFFIX = ".gpt56-sol-instruct.bak"
+STATE_FILENAME = ".gpt56-sol-instruct-state.json"
+STATE_VERSION = 1
 
 ANSI_RESET = "\033[0m"
 ANSI_BOLD = "\033[1m"
@@ -92,7 +95,7 @@ def intro_text() -> str:
 v5 提示词较为简单，足够应付多数场景（{zh_recommended}）。
 v35 提示词加入对特殊任务的优化，但安全性不如 v5（{zh_v35_notice}）。
 
-选择后会将相应提示词.md文件复制到CODEX_HOME中，在config.toml中写入model_instructions_file项，并创建config.toml的备份。若要卸载提示词并恢复原样，请选择“去除提示词恢复备份”项，或手动删除model_instructions_file配置项。
+选择后会将相应提示词.md文件复制到CODEX_HOME中，在config.toml中写入model_instructions_file项，并创建操作前快照。卸载时只恢复这一项，不会覆盖CCSwitch管理的provider、模型或认证配置。
 
 {en_banner}
 {en_title}
@@ -100,7 +103,7 @@ v35 提示词加入对特殊任务的优化，但安全性不如 v5（{zh_v35_no
 v5 instructions are simpler and sufficient for most scenarios ({en_recommended}).
 v35 instructions add optimizations for specialized tasks, but are less safe than v5 ({en_v35_notice}).
 
-After a version is selected, its prompt .md file is copied to CODEX_HOME, the model_instructions_file entry is written to config.toml, and config.toml is backed up. To uninstall the prompt and restore the previous state, choose “Reset to backup”, or manually remove the model_instructions_file entry.
+After a version is selected, its prompt .md file is copied to CODEX_HOME, the model_instructions_file entry is written to config.toml, and a pre-operation snapshot is created. Uninstall restores only that entry and never replaces provider, model, or authentication settings managed by CCSwitch.
 """
 
 
@@ -116,7 +119,7 @@ def menu_text() -> str:
 {selection_banner}
 1. 植入 v5 提示词 / Apply v5 instructions file （{recommendation}）
 2. 植入 v35 提示词 / Apply v35 instructions file （{v35_notice}）
-3. 去除提示词并恢复备份 / Reset to backup
+3. 去除提示词并恢复原配置项 / Remove managed instructions
 q. 退出而不执行任何操作 / Quit without modification
 """
 
@@ -147,81 +150,196 @@ def baseline_backup_path(config_path: Path) -> Path:
     return config_path.with_name(config_path.name + BASELINE_BACKUP_SUFFIX)
 
 
-def available_backups(config_path: Path) -> list[Path]:
-    baseline = baseline_backup_path(config_path)
-    candidates = {
-        path.resolve()
-        for path in config_path.parent.glob(config_path.name + "*.bak*")
-        if path.is_file()
-    }
-    ordered: list[Path] = []
-    if baseline.is_file():
-        ordered.append(baseline.resolve())
-        candidates.discard(baseline.resolve())
-    ordered.extend(
-        sorted(
-            candidates,
-            key=lambda path: (path.stat().st_mtime_ns, path.name),
-            reverse=True,
-        )
-    )
-    return ordered
+def state_file_path(config_path: Path) -> Path:
+    return config_path.parent / STATE_FILENAME
 
 
-def config_references_managed_prompt(config_path: Path) -> bool:
-    if not config_path.exists():
+def top_level_model_instructions_line(text: str) -> str | None:
+    """Return the root model_instructions_file assignment, ignoring TOML tables."""
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("["):
+            break
+        if re.match(r"^\s*model_instructions_file\s*=", line):
+            return line
+    return None
+
+
+def line_references_managed_prompt(line: str | None, filenames: set[str]) -> bool:
+    if not line:
         return False
-    for line in config_path.read_text(encoding="utf-8").splitlines():
-        if re.match(r"^\s*model_instructions_file\s*=", line) and any(
-            filename in line for filename in MANAGED_PROMPT_FILENAMES
+    match = re.match(
+        r"^\s*model_instructions_file\s*=\s*(['\"])(.*?)\1\s*(?:#.*)?$",
+        line,
+    )
+    if not match:
+        return False
+    referenced_name = match.group(2).replace("\\", "/").rsplit("/", 1)[-1]
+    return referenced_name in filenames
+
+
+def replace_top_level_model_instructions(text: str, replacement: str | None) -> str:
+    """Replace only the root assignment while preserving all unrelated TOML text."""
+    lines = text.splitlines(keepends=True)
+    table_index = next(
+        (index for index, line in enumerate(lines) if line.lstrip().startswith("[")),
+        len(lines),
+    )
+    assignment_indexes = [
+        index
+        for index, line in enumerate(lines[:table_index])
+        if re.match(r"^\s*model_instructions_file\s*=", line)
+    ]
+
+    if assignment_indexes:
+        first = assignment_indexes[0]
+        newline = (
+            "\r\n"
+            if lines[first].endswith("\r\n")
+            else "\n"
+            if lines[first].endswith("\n")
+            else ""
+        )
+        if replacement is None:
+            del lines[first]
+        else:
+            lines[first] = replacement + newline
+        return "".join(lines)
+
+    if replacement is None:
+        return text
+
+    insert_at = next(
+        (
+            index + 1
+            for index, line in enumerate(lines[:table_index])
+            if re.match(r"^\s*model\s*=", line)
+        ),
+        table_index,
+    )
+    newline = "\r\n" if any(line.endswith("\r\n") for line in lines) else "\n"
+    if insert_at > 0 and lines[insert_at - 1] and not lines[insert_at - 1].endswith("\n"):
+        lines[insert_at - 1] += newline
+    lines.insert(insert_at, replacement + newline)
+    return "".join(lines)
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Atomically replace a text file while retaining its existing permissions."""
+    previous_mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, previous_mode)
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def read_state(config_path: Path) -> dict[str, object] | None:
+    path = state_file_path(config_path)
+    if not path.exists():
+        return None
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
+        return None
+    return state
+
+
+def save_state(config_path: Path, state: dict[str, object]) -> None:
+    atomic_write_text(
+        state_file_path(config_path),
+        json.dumps(state, ensure_ascii=False, indent=2) + "\n",
+    )
+
+
+def previous_instruction_from_legacy_baseline(config_path: Path) -> str | None:
+    """Migrate only the old instruction entry, never provider data, from a legacy backup."""
+    baseline = baseline_backup_path(config_path)
+    if not baseline.exists():
+        return None
+    line = top_level_model_instructions_line(baseline.read_text(encoding="utf-8"))
+    if line_references_managed_prompt(line, MANAGED_PROMPT_FILENAMES):
+        return None
+    return line
+
+
+def prepare_deployment_state(config_path: Path, md_filename: str) -> dict[str, object]:
+    state = read_state(config_path)
+    if state is None:
+        current_line = top_level_model_instructions_line(
+            config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+        )
+        if line_references_managed_prompt(
+            current_line,
+            MANAGED_PROMPT_FILENAMES | {md_filename},
         ):
-            return True
-    return False
+            current_line = previous_instruction_from_legacy_baseline(config_path)
+        state = {
+            "version": STATE_VERSION,
+            "previous_model_instructions_line": current_line,
+            "managed_prompt_filenames": [],
+        }
+
+    stored_filenames = state.get("managed_prompt_filenames", [])
+    filenames = (
+        {name for name in stored_filenames if isinstance(name, str)}
+        if isinstance(stored_filenames, list)
+        else set()
+    )
+    filenames.add(md_filename)
+    state["managed_prompt_filenames"] = sorted(filenames)
+    save_state(config_path, state)
+    return state
 
 
 def set_model_instructions(config_path: Path, md_filename: str) -> bool:
     text = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
     target = f'model_instructions_file = "./{md_filename}"'
-    pattern = re.compile(r"^\s*model_instructions_file\s*=.*$", re.MULTILINE)
-    if pattern.search(text):
-        new_text = pattern.sub(target, text)
-    else:
-        lines = text.splitlines()
-        insert_at = None
-        for index, line in enumerate(lines):
-            if line.strip().startswith("model ") and "=" in line:
-                insert_at = index + 1
-                break
-        if insert_at is None:
-            insert_at = next(
-                (index for index, line in enumerate(lines) if line.lstrip().startswith("[")),
-                len(lines),
-            )
-        lines.insert(insert_at, target)
-        new_text = "\n".join(lines) + "\n"
+    new_text = replace_top_level_model_instructions(text, target)
     if new_text != text:
-        config_path.write_text(new_text, encoding="utf-8")
+        atomic_write_text(config_path, new_text)
         return True
     return False
 
 
-def remove_managed_model_instructions(config_path: Path) -> bool:
+def restore_managed_model_instructions(config_path: Path) -> tuple[bool, str]:
     if not config_path.exists():
-        return False
+        return False, "missing"
+
+    state = read_state(config_path)
+    managed_filenames = set(MANAGED_PROMPT_FILENAMES)
+    if state:
+        stored_filenames = state.get("managed_prompt_filenames", [])
+        if isinstance(stored_filenames, list):
+            managed_filenames.update(
+                name for name in stored_filenames if isinstance(name, str)
+            )
+
     text = config_path.read_text(encoding="utf-8")
-    lines = text.splitlines(keepends=True)
-    new_text = "".join(
-        line
-        for line in lines
-        if not (
-            re.match(r"^\s*model_instructions_file\s*=", line)
-            and any(filename in line for filename in MANAGED_PROMPT_FILENAMES)
-        )
-    )
+    current_line = top_level_model_instructions_line(text)
+    if not line_references_managed_prompt(current_line, managed_filenames):
+        return False, "not-managed"
+
+    previous_line = state.get("previous_model_instructions_line") if state else None
+    if previous_line is not None and not isinstance(previous_line, str):
+        previous_line = None
+    if state is None:
+        previous_line = previous_instruction_from_legacy_baseline(config_path)
+
+    new_text = replace_top_level_model_instructions(text, previous_line)
     if new_text != text:
-        config_path.write_text(new_text, encoding="utf-8")
-        return True
-    return False
+        atomic_write_text(config_path, new_text)
+        return True, "restored" if previous_line else "removed"
+    return False, "unchanged"
 
 
 def read_prompt(source_path: Path, expected_md_filename: str) -> str:
@@ -250,6 +368,9 @@ def deploy_prompt(
     prompt_path: Path,
     md_filename: str,
 ) -> int:
+    if Path(md_filename).name != md_filename or not md_filename.endswith(".md"):
+        print(f"[错误] 目标名称必须是不含路径的 .md 文件名: {md_filename}", file=sys.stderr)
+        return 2
     if not prompt_path.exists():
         print(f"[错误] 提示词文件不存在: {prompt_path}", file=sys.stderr)
         return 2
@@ -269,94 +390,42 @@ def deploy_prompt(
     print(f"[+] Prompt: {prompt_path} [{source_kind}]")
     for codex_dir in codex_dirs:
         config_path = codex_dir / "config.toml"
-        baseline = baseline_backup_path(config_path)
         destination = codex_dir / md_filename
         print(f"\n── 目标 / Target: {codex_dir} ──")
         print(f"  写入 / Write: {destination}")
         print(f'  配置 / Config: model_instructions_file = "./{md_filename}"')
-        print(f"  基线备份 / Baseline backup: {baseline.name}")
+        print("  兼容模式 / Compatibility: 仅修改本项目管理的配置项")
         if args.dry_run:
             continue
 
         codex_dir.mkdir(parents=True, exist_ok=True)
         if not config_path.exists():
-            config_path.write_text("", encoding="utf-8")
+            atomic_write_text(config_path, "")
             print("  创建 / Created: config.toml")
-        if not baseline.exists():
-            shutil.copy2(config_path, baseline)
-            print(f"  已创建基线备份 / Baseline saved: {baseline.name}")
-        elif not config_references_managed_prompt(config_path):
-            shutil.copy2(config_path, baseline)
-            print(f"  已刷新基线备份 / Baseline refreshed: {baseline.name}")
-        else:
-            print(f"  保留现有基线备份 / Baseline retained: {baseline.name}")
         snapshot = backup_file(config_path)
         print(f"  已创建操作前备份 / Snapshot saved: {snapshot.name}")
 
-        destination.write_text(prompt_text, encoding="utf-8")
+        prepare_deployment_state(config_path, md_filename)
+        atomic_write_text(destination, prompt_text)
         changed = set_model_instructions(config_path, md_filename)
         print("  状态 / Status:", "已更新 / Updated" if changed else "已是最新 / Already current")
     return 0
 
 
-def choose_backup(config_path: Path) -> tuple[Path | None, bool]:
-    backups = available_backups(config_path)
-    if not backups:
-        print("  未找到可恢复的 config.toml 备份。")
-        print("  No restorable config.toml backup was found.")
-        return None, True
-
-    print("  可用备份 / Available backups:")
-    baseline = baseline_backup_path(config_path).resolve()
-    for index, backup in enumerate(backups, start=1):
-        stat = backup.stat()
-        modified = datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M:%S")
-        label = (
-            "部署前基线 / Pre-deployment baseline"
-            if backup == baseline
-            else "操作快照 / Operation snapshot"
-        )
-        print(f"    {index}. {backup.name} [{label}; {modified}; {stat.st_size} bytes]")
-    print("    q. 取消恢复 / Cancel reset")
-
-    while True:
-        try:
-            choice = input(
-                f"请选择要恢复的文件 / Select a backup to restore [1-{len(backups)}/q]: "
-            ).strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            print()
-            return None, False
-        if choice == "q":
-            return None, False
-        if choice.isdigit() and 1 <= int(choice) <= len(backups):
-            return backups[int(choice) - 1], True
-        print(
-            f"[错误] 请输入 1-{len(backups)} 或 q / "
-            f"Enter a number from 1 to {len(backups)}, or q."
-        )
-
-
-def confirm_reset(restore_source: Path | None) -> bool:
-    if restore_source:
-        print(f"  将恢复 / Selected backup: {restore_source}")
-        print("  该文件将覆盖 config.toml，并移除脚本管理的提示词文件。")
-        print("  This file will replace config.toml, and managed prompt files will be removed.")
-    else:
-        print("  没有可用备份；将仅移除脚本管理的 model_instructions_file 配置和提示词文件。")
-        print(
-            "  No backup is available; only the managed model_instructions_file entry "
-            "and prompt files will be removed."
-        )
+def confirm_reset() -> bool:
+    print("  将只恢复本脚本管理的 model_instructions_file，并移除提示词文件。")
+    print("  provider、模型、认证及CCSwitch在部署后写入的其他配置均保持不变。")
+    print("  Only the managed model_instructions_file entry and prompt files will change.")
+    print("  Provider, model, authentication, and later CCSwitch changes will be preserved.")
     try:
-        answer = input("确认继续？/ Confirm reset? [y/N]: ").strip().lower()
+        answer = input("确认继续？/ Confirm removal? [y/N]: ").strip().lower()
     except (EOFError, KeyboardInterrupt):
         print()
         return False
     return answer in {"y", "yes", "是"}
 
 
-def reset_to_backup(args: argparse.Namespace) -> int:
+def reset_managed_install(args: argparse.Namespace) -> int:
     codex_dirs = selected_codex_dirs(args.codex_dir)
     if not codex_dirs:
         print("[错误] 未找到 .codex/config.toml；请使用 --codex-dir 指定。", file=sys.stderr)
@@ -365,19 +434,23 @@ def reset_to_backup(args: argparse.Namespace) -> int:
     for codex_dir in codex_dirs:
         config_path = codex_dir / "config.toml"
         print(f"\n── 目标 / Target: {codex_dir} ──")
-        restore_source, should_continue = choose_backup(config_path)
-        if not should_continue:
-            print("  已取消 / Reset cancelled.")
-            continue
-        if not confirm_reset(restore_source):
+        state = read_state(config_path)
+        managed_filenames = set(MANAGED_PROMPT_FILENAMES)
+        if state:
+            stored_filenames = state.get("managed_prompt_filenames", [])
+            if isinstance(stored_filenames, list):
+                managed_filenames.update(
+                    name
+                    for name in stored_filenames
+                    if isinstance(name, str) and Path(name).name == name
+                )
+
+        if not confirm_reset():
             print("  未确认，已取消 / Confirmation not received; reset cancelled.")
             continue
 
-        if restore_source:
-            print(f"  恢复 / Restore: {restore_source.name} -> config.toml")
-        else:
-            print("  恢复 / Restore: 无备份，将移除脚本管理的配置项")
-        for filename in sorted(MANAGED_PROMPT_FILENAMES):
+        print("  配置 / Config: 字段级恢复，不覆盖 config.toml")
+        for filename in sorted(managed_filenames):
             print(f"  移除 / Remove: {filename}")
         if args.dry_run:
             print("  预览完成，未修改文件 / Dry run complete; no files changed.")
@@ -388,32 +461,25 @@ def reset_to_backup(args: argparse.Namespace) -> int:
             snapshot = backup_file(config_path)
             print(f"  已创建恢复前备份 / Pre-reset snapshot: {snapshot.name}")
 
-        if restore_source:
-            shutil.copy2(restore_source, config_path)
-            removed_entry = remove_managed_model_instructions(config_path)
-            print(
-                "  配置状态 / Config status:",
-                "已恢复备份并移除脚本配置 / Backup restored; managed entry removed"
-                if removed_entry
-                else "已恢复备份 / Backup restored",
-            )
-        elif config_path.exists():
-            changed = remove_managed_model_instructions(config_path)
-            print(
-                "  配置状态 / Config status:",
-                "已移除脚本配置项 / Managed entry removed"
-                if changed
-                else "未发现脚本配置项 / Managed entry not found",
-            )
-        else:
-            print("  配置状态 / Config status: config.toml 不存在 / Not found")
+        _changed, status = restore_managed_model_instructions(config_path)
+        status_messages = {
+            "restored": "已恢复原配置项 / Previous entry restored",
+            "removed": "已移除脚本配置项 / Managed entry removed",
+            "not-managed": "当前配置项不属于本脚本，保持不变 / Current entry left unchanged",
+            "missing": "config.toml 不存在 / Not found",
+            "unchanged": "无需修改 / No change needed",
+        }
+        print("  配置状态 / Config status:", status_messages[status])
 
         removed = 0
-        for filename in MANAGED_PROMPT_FILENAMES:
+        for filename in managed_filenames:
             prompt_path = codex_dir / filename
             if prompt_path.exists():
                 prompt_path.unlink()
                 removed += 1
+        state_path = state_file_path(config_path)
+        if state_path.exists():
+            state_path.unlink()
         print(f"  提示词状态 / Prompt status: 已移除 {removed} 个文件 / Removed {removed} file(s)")
     return 0
 
@@ -445,7 +511,11 @@ def main() -> int:
     )
     action_group = parser.add_mutually_exclusive_group()
     action_group.add_argument("--version", choices=("v5", "v35"), help="Apply v5 or v35")
-    action_group.add_argument("--reset", action="store_true", help="Restore the backup and remove prompts")
+    action_group.add_argument(
+        "--reset",
+        action="store_true",
+        help="Remove managed prompts without replacing config.toml",
+    )
     action_group.add_argument("--file", "-f", help="Apply a custom instruction ZIP or Markdown file")
     parser.add_argument("--name", "-n", help="Destination filename for --file, with or without .md")
     parser.add_argument("--codex-dir", help="Explicit Codex home directory, e.g. ~/.codex")
@@ -469,7 +539,7 @@ def main() -> int:
         print("未执行修改 / No modification made.")
         return 0
     if action == "reset":
-        return reset_to_backup(args)
+        return reset_managed_install(args)
 
     selected = PROMPT_VERSIONS[action]
     return deploy_prompt(args, selected["archive"], selected["md_filename"])

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -11,6 +11,7 @@ whole config.toml, so provider managers such as CCSwitch remain authoritative.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -38,7 +39,11 @@ MANAGED_PROMPT_FILENAMES = {
 }
 BASELINE_BACKUP_SUFFIX = ".gpt56-sol-instruct.bak"
 STATE_FILENAME = ".gpt56-sol-instruct-state.json"
-STATE_VERSION = 1
+STATE_VERSION = 2
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+MODEL_INSTRUCTIONS_PATTERN = re.compile(
+    r"^\s*model_instructions_file\s*=\s*(['\"])(.*?)\1\s*(?:#.*)?$"
+)
 
 ANSI_RESET = "\033[0m"
 ANSI_BOLD = "\033[1m"
@@ -154,6 +159,38 @@ def state_file_path(config_path: Path) -> Path:
     return config_path.parent / STATE_FILENAME
 
 
+def is_safe_prompt_filename(filename: object) -> bool:
+    return (
+        isinstance(filename, str)
+        and bool(filename)
+        and "/" not in filename
+        and "\\" not in filename
+        and filename.lower().endswith(".md")
+        and Path(filename).name == filename
+    )
+
+
+def prompt_sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def is_valid_instruction_line(line: object) -> bool:
+    return (
+        isinstance(line, str)
+        and "\n" not in line
+        and "\r" not in line
+        and MODEL_INSTRUCTIONS_PATTERN.fullmatch(line) is not None
+    )
+
+
 def top_level_model_instructions_line(text: str) -> str | None:
     """Return the root model_instructions_file assignment, ignoring TOML tables."""
     for line in text.splitlines():
@@ -168,14 +205,15 @@ def top_level_model_instructions_line(text: str) -> str | None:
 def line_references_managed_prompt(line: str | None, filenames: set[str]) -> bool:
     if not line:
         return False
-    match = re.match(
-        r"^\s*model_instructions_file\s*=\s*(['\"])(.*?)\1\s*(?:#.*)?$",
-        line,
-    )
+    match = MODEL_INSTRUCTIONS_PATTERN.fullmatch(line)
     if not match:
         return False
-    referenced_name = match.group(2).replace("\\", "/").rsplit("/", 1)[-1]
-    return referenced_name in filenames
+    reference = match.group(2).replace("\\", "/")
+    if reference.startswith("./"):
+        reference = reference[2:]
+    if "/" in reference:
+        return False
+    return reference in filenames
 
 
 def replace_top_level_model_instructions(text: str, replacement: str | None) -> str:
@@ -224,10 +262,16 @@ def replace_top_level_model_instructions(text: str, replacement: str | None) -> 
     return "".join(lines)
 
 
-def atomic_write_text(path: Path, text: str) -> None:
-    """Atomically replace a text file while retaining its existing permissions."""
-    previous_mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
-    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+def atomic_write_text(path: Path, text: str, *, follow_symlink: bool = False) -> None:
+    """Atomically update text, following symlinks only for explicitly trusted paths."""
+    if path.is_symlink() and not follow_symlink:
+        raise OSError(f"refusing to overwrite symlink: {path}")
+    write_path = path.resolve(strict=False) if path.is_symlink() else path
+    previous_mode = write_path.stat().st_mode & 0o777 if write_path.exists() else 0o600
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{write_path.name}.",
+        dir=write_path.parent,
+    )
     temporary_path = Path(temporary_name)
     try:
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
@@ -235,7 +279,7 @@ def atomic_write_text(path: Path, text: str) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.chmod(temporary_path, previous_mode)
-        os.replace(temporary_path, path)
+        os.replace(temporary_path, write_path)
     finally:
         if temporary_path.exists():
             temporary_path.unlink()
@@ -251,7 +295,34 @@ def read_state(config_path: Path) -> dict[str, object] | None:
         return None
     if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
         return None
-    return state
+
+    previous_line = state.get("previous_model_instructions_line")
+    if previous_line is not None and not is_valid_instruction_line(previous_line):
+        return None
+
+    stored_prompts = state.get("managed_prompts")
+    if not isinstance(stored_prompts, dict):
+        return None
+    managed_prompts: dict[str, dict[str, object]] = {}
+    for filename, metadata in stored_prompts.items():
+        if not is_safe_prompt_filename(filename) or not isinstance(metadata, dict):
+            return None
+        digest = metadata.get("sha256")
+        if not isinstance(digest, str) or not SHA256_PATTERN.fullmatch(digest):
+            return None
+        existed_before = metadata.get("existed_before")
+        if not isinstance(existed_before, bool):
+            return None
+        managed_prompts[filename] = {
+            "sha256": digest,
+            "existed_before": existed_before,
+        }
+
+    return {
+        "version": STATE_VERSION,
+        "previous_model_instructions_line": previous_line,
+        "managed_prompts": managed_prompts,
+    }
 
 
 def save_state(config_path: Path, state: dict[str, object]) -> None:
@@ -272,7 +343,12 @@ def previous_instruction_from_legacy_baseline(config_path: Path) -> str | None:
     return line
 
 
-def prepare_deployment_state(config_path: Path, md_filename: str) -> dict[str, object]:
+def prepare_deployment_state(
+    config_path: Path,
+    md_filename: str,
+    prompt_text: str,
+    existed_before: bool = False,
+) -> dict[str, object]:
     state = read_state(config_path)
     if state is None:
         current_line = top_level_model_instructions_line(
@@ -286,17 +362,21 @@ def prepare_deployment_state(config_path: Path, md_filename: str) -> dict[str, o
         state = {
             "version": STATE_VERSION,
             "previous_model_instructions_line": current_line,
-            "managed_prompt_filenames": [],
+            "managed_prompts": {},
         }
 
-    stored_filenames = state.get("managed_prompt_filenames", [])
-    filenames = (
-        {name for name in stored_filenames if isinstance(name, str)}
-        if isinstance(stored_filenames, list)
-        else set()
+    managed_prompts = state["managed_prompts"]
+    assert isinstance(managed_prompts, dict)
+    previous_metadata = managed_prompts.get(md_filename)
+    was_preexisting = (
+        previous_metadata.get("existed_before", existed_before)
+        if isinstance(previous_metadata, dict)
+        else existed_before
     )
-    filenames.add(md_filename)
-    state["managed_prompt_filenames"] = sorted(filenames)
+    managed_prompts[md_filename] = {
+        "sha256": prompt_sha256(prompt_text),
+        "existed_before": bool(was_preexisting),
+    }
     save_state(config_path, state)
     return state
 
@@ -306,7 +386,7 @@ def set_model_instructions(config_path: Path, md_filename: str) -> bool:
     target = f'model_instructions_file = "./{md_filename}"'
     new_text = replace_top_level_model_instructions(text, target)
     if new_text != text:
-        atomic_write_text(config_path, new_text)
+        atomic_write_text(config_path, new_text, follow_symlink=True)
         return True
     return False
 
@@ -318,11 +398,9 @@ def restore_managed_model_instructions(config_path: Path) -> tuple[bool, str]:
     state = read_state(config_path)
     managed_filenames = set(MANAGED_PROMPT_FILENAMES)
     if state:
-        stored_filenames = state.get("managed_prompt_filenames", [])
-        if isinstance(stored_filenames, list):
-            managed_filenames.update(
-                name for name in stored_filenames if isinstance(name, str)
-            )
+        stored_prompts = state.get("managed_prompts", {})
+        if isinstance(stored_prompts, dict):
+            managed_filenames.update(stored_prompts)
 
     text = config_path.read_text(encoding="utf-8")
     current_line = top_level_model_instructions_line(text)
@@ -337,7 +415,7 @@ def restore_managed_model_instructions(config_path: Path) -> tuple[bool, str]:
 
     new_text = replace_top_level_model_instructions(text, previous_line)
     if new_text != text:
-        atomic_write_text(config_path, new_text)
+        atomic_write_text(config_path, new_text, follow_symlink=True)
         return True, "restored" if previous_line else "removed"
     return False, "unchanged"
 
@@ -368,7 +446,7 @@ def deploy_prompt(
     prompt_path: Path,
     md_filename: str,
 ) -> int:
-    if Path(md_filename).name != md_filename or not md_filename.endswith(".md"):
+    if not is_safe_prompt_filename(md_filename):
         print(f"[错误] 目标名称必须是不含路径的 .md 文件名: {md_filename}", file=sys.stderr)
         return 2
     if not prompt_path.exists():
@@ -400,12 +478,51 @@ def deploy_prompt(
 
         codex_dir.mkdir(parents=True, exist_ok=True)
         if not config_path.exists():
-            atomic_write_text(config_path, "")
+            atomic_write_text(config_path, "", follow_symlink=True)
             print("  创建 / Created: config.toml")
+
+        if state_file_path(config_path).is_symlink():
+            print(
+                f"[错误] 状态文件不能是符号链接: {state_file_path(config_path)}",
+                file=sys.stderr,
+            )
+            print("[Error] State file must not be a symlink.", file=sys.stderr)
+            return 2
+
+        state = read_state(config_path)
+        tracked_prompts = state.get("managed_prompts", {}) if state else {}
+        current_line = top_level_model_instructions_line(
+            config_path.read_text(encoding="utf-8")
+        )
+        legacy_owned = state is None and line_references_managed_prompt(
+            current_line,
+            {md_filename},
+        )
+        if (
+            (destination.exists() or destination.is_symlink())
+            and md_filename not in tracked_prompts
+            and not legacy_owned
+        ):
+            print(
+                f"[错误] 目标文件已存在且不属于本脚本，未覆盖: {destination}",
+                file=sys.stderr,
+            )
+            print(
+                "[Error] Destination exists but is not owned by this script; "
+                "choose another --name.",
+                file=sys.stderr,
+            )
+            return 2
+
         snapshot = backup_file(config_path)
         print(f"  已创建操作前备份 / Snapshot saved: {snapshot.name}")
 
-        prepare_deployment_state(config_path, md_filename)
+        prepare_deployment_state(
+            config_path,
+            md_filename,
+            prompt_text,
+            existed_before=destination.exists() or destination.is_symlink(),
+        )
         atomic_write_text(destination, prompt_text)
         changed = set_model_instructions(config_path, md_filename)
         print("  状态 / Status:", "已更新 / Updated" if changed else "已是最新 / Already current")
@@ -425,6 +542,76 @@ def confirm_reset() -> bool:
     return answer in {"y", "yes", "是"}
 
 
+def confirm_snapshot_restore(snapshot: Path) -> bool:
+    print(f"  将使用整份快照覆盖当前 config.toml / Full snapshot: {snapshot}")
+    print("  这可能恢复旧的 provider、模型或认证配置，请仅用于人工应急恢复。")
+    print("  This may restore old provider, model, or authentication settings.")
+    try:
+        answer = input("确认完整恢复？/ Confirm full restore? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    return answer in {"y", "yes", "是"}
+
+
+def restore_config_snapshot(args: argparse.Namespace, snapshot: Path) -> int:
+    codex_dirs = selected_codex_dirs(args.codex_dir)
+    if len(codex_dirs) != 1:
+        print(
+            "[错误] 完整快照恢复必须使用 --codex-dir 指定唯一目标。",
+            file=sys.stderr,
+        )
+        print(
+            "[Error] Full snapshot restore requires exactly one --codex-dir target.",
+            file=sys.stderr,
+        )
+        return 2
+
+    codex_dir = codex_dirs[0]
+    config_path = codex_dir / "config.toml"
+    snapshot = snapshot.expanduser().resolve()
+    allowed_names = {
+        config_path.name + BASELINE_BACKUP_SUFFIX,
+    }
+    valid_name = (
+        snapshot.name.startswith(config_path.name + ".bak_")
+        or snapshot.name in allowed_names
+    )
+    if snapshot.parent != codex_dir.resolve() or not snapshot.is_file() or not valid_name:
+        print(
+            "[错误] 快照必须是目标 CODEX_HOME 中由本脚本创建的 config.toml 备份。",
+            file=sys.stderr,
+        )
+        print(
+            "[Error] Snapshot must be a config.toml backup inside the target CODEX_HOME.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        snapshot_text = snapshot.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        print(f"[错误] 无法读取快照 / Failed to read snapshot: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"[+] Snapshot: {snapshot}")
+    print(f"[+] Target: {config_path}")
+    if args.dry_run:
+        print("  预览完成，未修改文件 / Dry run complete; no files changed.")
+        return 0
+    if not confirm_snapshot_restore(snapshot):
+        print("  未确认，已取消 / Confirmation not received; restore cancelled.")
+        return 0
+
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    if config_path.exists():
+        safety_snapshot = backup_file(config_path)
+        print(f"  已备份当前配置 / Current config saved: {safety_snapshot.name}")
+    atomic_write_text(config_path, snapshot_text, follow_symlink=True)
+    print("  已完整恢复 config.toml / Full config.toml restored.")
+    return 0
+
+
 def reset_managed_install(args: argparse.Namespace) -> int:
     codex_dirs = selected_codex_dirs(args.codex_dir)
     if not codex_dirs:
@@ -435,23 +622,18 @@ def reset_managed_install(args: argparse.Namespace) -> int:
         config_path = codex_dir / "config.toml"
         print(f"\n── 目标 / Target: {codex_dir} ──")
         state = read_state(config_path)
-        managed_filenames = set(MANAGED_PROMPT_FILENAMES)
-        if state:
-            stored_filenames = state.get("managed_prompt_filenames", [])
-            if isinstance(stored_filenames, list):
-                managed_filenames.update(
-                    name
-                    for name in stored_filenames
-                    if isinstance(name, str) and Path(name).name == name
-                )
+        managed_prompts = state.get("managed_prompts", {}) if state else {}
+        assert isinstance(managed_prompts, dict)
 
         if not confirm_reset():
             print("  未确认，已取消 / Confirmation not received; reset cancelled.")
             continue
 
         print("  配置 / Config: 字段级恢复，不覆盖 config.toml")
-        for filename in sorted(managed_filenames):
-            print(f"  移除 / Remove: {filename}")
+        for filename in sorted(managed_prompts):
+            print(f"  校验后移除 / Verify then remove: {filename}")
+        if not managed_prompts:
+            print("  提示词 / Prompts: 无可信状态记录，不自动删除文件")
         if args.dry_run:
             print("  预览完成，未修改文件 / Dry run complete; no files changed.")
             continue
@@ -472,15 +654,40 @@ def reset_managed_install(args: argparse.Namespace) -> int:
         print("  配置状态 / Config status:", status_messages[status])
 
         removed = 0
-        for filename in managed_filenames:
+        preserved = 0
+        for filename, metadata in managed_prompts.items():
             prompt_path = codex_dir / filename
-            if prompt_path.exists():
+            expected_digest = metadata.get("sha256") if isinstance(metadata, dict) else None
+            existed_before = (
+                metadata.get("existed_before", True) if isinstance(metadata, dict) else True
+            )
+            try:
+                digest_matches = (
+                    not existed_before
+                    and prompt_path.is_file()
+                    and bool(expected_digest)
+                    and file_sha256(prompt_path) == expected_digest
+                )
+            except OSError:
+                digest_matches = False
+            if digest_matches:
                 prompt_path.unlink()
                 removed += 1
+            elif prompt_path.exists():
+                preserved += 1
+                reason = (
+                    "部署前已存在 / pre-existing"
+                    if existed_before
+                    else "用户已修改 / user-modified"
+                )
+                print(f"  已保留文件 / Preserved file ({reason}): {prompt_path.name}")
         state_path = state_file_path(config_path)
         if state_path.exists():
             state_path.unlink()
-        print(f"  提示词状态 / Prompt status: 已移除 {removed} 个文件 / Removed {removed} file(s)")
+        print(
+            "  提示词状态 / Prompt status: "
+            f"已移除 {removed} 个，保留 {preserved} 个 / Removed {removed}, preserved {preserved}"
+        )
     return 0
 
 
@@ -516,6 +723,11 @@ def main() -> int:
         action="store_true",
         help="Remove managed prompts without replacing config.toml",
     )
+    action_group.add_argument(
+        "--restore-snapshot",
+        metavar="PATH",
+        help="Explicitly restore one full config.toml snapshot",
+    )
     action_group.add_argument("--file", "-f", help="Apply a custom instruction ZIP or Markdown file")
     parser.add_argument("--name", "-n", help="Destination filename for --file, with or without .md")
     parser.add_argument("--codex-dir", help="Explicit Codex home directory, e.g. ~/.codex")
@@ -529,6 +741,8 @@ def main() -> int:
         action = args.version
     elif args.reset:
         action = "reset"
+    elif args.restore_snapshot:
+        return restore_config_snapshot(args, Path(args.restore_snapshot))
     elif args.file:
         source = Path(args.file).expanduser().resolve()
         return deploy_prompt(args, source, inferred_md_filename(source, args.name))

--- a/unit_tests/test_codex_instruct.py
+++ b/unit_tests/test_codex_instruct.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "codex_instruct",
+    PROJECT_ROOT / "codex-instruct.py",
+)
+assert SPEC and SPEC.loader
+codex_instruct = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(codex_instruct)
+
+
+class ManagedConfigTests(unittest.TestCase):
+    def make_config(self, text: str) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+        temporary_directory = tempfile.TemporaryDirectory()
+        config_path = Path(temporary_directory.name) / "config.toml"
+        config_path.write_text(text, encoding="utf-8")
+        return temporary_directory, config_path
+
+    def test_reset_preserves_ccswitch_provider_change(self) -> None:
+        temporary_directory, config_path = self.make_config(
+            'model_provider = "custom"\n'
+            'model = "gpt-5.5"\n\n'
+            '[model_providers.custom]\n'
+            'base_url = "https://example.invalid/v1"\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+
+        codex_instruct.prepare_deployment_state(
+            config_path,
+            "gpt-5.6-sol-unrestricted-v5.md",
+        )
+        codex_instruct.set_model_instructions(
+            config_path,
+            "gpt-5.6-sol-unrestricted-v5.md",
+        )
+
+        # Simulate CCSwitch selecting the official provider after deployment.
+        config_path.write_text(
+            'model_provider = "openai"\n'
+            'model = "gpt-5.5"\n'
+            'model_instructions_file = "./gpt-5.6-sol-unrestricted-v5.md"\n\n'
+            '[features]\nweb_search = true\n',
+            encoding="utf-8",
+        )
+
+        changed, status = codex_instruct.restore_managed_model_instructions(config_path)
+
+        self.assertTrue(changed)
+        self.assertEqual(status, "removed")
+        restored = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(restored["model_provider"], "openai")
+        self.assertTrue(restored["features"]["web_search"])
+        self.assertNotIn("model_instructions_file", restored)
+
+    def test_round_trip_restores_previous_instruction_entry(self) -> None:
+        original_line = 'model_instructions_file = "./personal-instructions.md" # keep me'
+        temporary_directory, config_path = self.make_config(
+            f'model = "gpt-5.5"\n{original_line}\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+
+        codex_instruct.prepare_deployment_state(
+            config_path,
+            "gpt-5.6-sol-unrestricted-v35.md",
+        )
+        codex_instruct.set_model_instructions(
+            config_path,
+            "gpt-5.6-sol-unrestricted-v35.md",
+        )
+        changed, status = codex_instruct.restore_managed_model_instructions(config_path)
+
+        self.assertTrue(changed)
+        self.assertEqual(status, "restored")
+        self.assertIn(original_line, config_path.read_text(encoding="utf-8"))
+
+    def test_nested_assignment_is_not_rewritten(self) -> None:
+        nested_line = 'model_instructions_file = "nested-value.md"'
+        temporary_directory, config_path = self.make_config(
+            f'[profile.test]\n{nested_line}\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+
+        codex_instruct.prepare_deployment_state(
+            config_path,
+            "gpt-5.6-sol-unrestricted-v5.md",
+        )
+        codex_instruct.set_model_instructions(
+            config_path,
+            "gpt-5.6-sol-unrestricted-v5.md",
+        )
+        codex_instruct.restore_managed_model_instructions(config_path)
+
+        text = config_path.read_text(encoding="utf-8")
+        self.assertEqual(text.count(nested_line), 1)
+        self.assertNotIn("gpt-5.6-sol-unrestricted-v5.md", text)
+
+    def test_legacy_baseline_migrates_only_previous_instruction(self) -> None:
+        temporary_directory, config_path = self.make_config(
+            'model_provider = "openai"\n'
+            'model_instructions_file = "./gpt-5.6-sol-unrestricted-v5.md"\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+        baseline = codex_instruct.baseline_backup_path(config_path)
+        baseline.write_text(
+            'model_provider = "custom"\n'
+            'model_instructions_file = "./personal.md"\n\n'
+            '[model_providers.custom]\nbase_url = "https://example.invalid/v1"\n',
+            encoding="utf-8",
+        )
+
+        changed, status = codex_instruct.restore_managed_model_instructions(config_path)
+
+        self.assertTrue(changed)
+        self.assertEqual(status, "restored")
+        restored = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(restored["model_provider"], "openai")
+        self.assertEqual(restored["model_instructions_file"], "./personal.md")
+        self.assertNotIn("model_providers", restored)
+
+    def test_custom_prompt_filename_is_tracked(self) -> None:
+        temporary_directory, config_path = self.make_config('model = "gpt-5.5"\n')
+        self.addCleanup(temporary_directory.cleanup)
+        filename = "custom-prompt.md"
+
+        codex_instruct.prepare_deployment_state(config_path, filename)
+        codex_instruct.set_model_instructions(config_path, filename)
+        changed, status = codex_instruct.restore_managed_model_instructions(config_path)
+
+        self.assertTrue(changed)
+        self.assertEqual(status, "removed")
+        self.assertNotIn("model_instructions_file", config_path.read_text(encoding="utf-8"))
+
+    def test_full_reset_removes_state_and_prompt_without_reverting_provider(self) -> None:
+        temporary_directory, config_path = self.make_config(
+            'model_provider = "custom"\nmodel = "gpt-5.5"\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+        codex_home = config_path.parent
+        source = codex_home / "source.md"
+        source.write_text("test instructions\n", encoding="utf-8")
+        args = SimpleNamespace(codex_dir=str(codex_home), dry_run=False)
+
+        result = codex_instruct.deploy_prompt(args, source, "custom-prompt.md")
+        self.assertEqual(result, 0)
+
+        # CCSwitch changes provider state while retaining the common instruction entry.
+        config_path.write_text(
+            'model_provider = "openai"\n'
+            'model_instructions_file = "./custom-prompt.md"\n',
+            encoding="utf-8",
+        )
+        with patch("builtins.input", return_value="y"):
+            result = codex_instruct.reset_managed_install(args)
+
+        self.assertEqual(result, 0)
+        restored = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(restored["model_provider"], "openai")
+        self.assertNotIn("model_instructions_file", restored)
+        self.assertFalse((codex_home / "custom-prompt.md").exists())
+        self.assertFalse(codex_instruct.state_file_path(config_path).exists())
+
+    def test_crlf_line_endings_are_preserved(self) -> None:
+        text = 'model = "gpt-5.5"\r\n[features]\r\nweb_search = true\r\n'
+        updated = codex_instruct.replace_top_level_model_instructions(
+            text,
+            'model_instructions_file = "./prompt.md"',
+        )
+
+        self.assertNotIn("\n", updated.replace("\r\n", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/test_codex_instruct.py
+++ b/unit_tests/test_codex_instruct.py
@@ -31,6 +31,7 @@ class ManagedConfigTests(unittest.TestCase):
         config_path.write_text(text, encoding="utf-8")
         return temporary_directory, config_path
 
+    # Reset removes only the managed instruction entry and preserves later CCSwitch settings.
     def test_reset_preserves_ccswitch_provider_change(self) -> None:
         temporary_directory, config_path = self.make_config(
             'model_provider = "custom"\n'
@@ -68,6 +69,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertTrue(restored["features"]["web_search"])
         self.assertNotIn("model_instructions_file", restored)
 
+    # A pre-existing top-level instruction line, including its comment, survives deploy/reset.
     def test_round_trip_restores_previous_instruction_entry(self) -> None:
         original_line = 'model_instructions_file = "./personal-instructions.md" # keep me'
         temporary_directory, config_path = self.make_config(
@@ -90,6 +92,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(status, "restored")
         self.assertIn(original_line, config_path.read_text(encoding="utf-8"))
 
+    # Assignments inside TOML tables are not mistaken for the managed top-level field.
     def test_nested_assignment_is_not_rewritten(self) -> None:
         nested_line = 'model_instructions_file = "nested-value.md"'
         temporary_directory, config_path = self.make_config(
@@ -112,6 +115,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(text.count(nested_line), 1)
         self.assertNotIn("gpt-5.6-sol-unrestricted-v5.md", text)
 
+    # Legacy backups contribute only the prior instruction entry, never stale provider data.
     def test_legacy_baseline_migrates_only_previous_instruction(self) -> None:
         temporary_directory, config_path = self.make_config(
             'model_provider = "openai"\n'
@@ -135,6 +139,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(restored["model_instructions_file"], "./personal.md")
         self.assertNotIn("model_providers", restored)
 
+    # Custom prompt names are recorded so their managed config entry can be removed safely.
     def test_custom_prompt_filename_is_tracked(self) -> None:
         temporary_directory, config_path = self.make_config('model = "gpt-5.5"\n')
         self.addCleanup(temporary_directory.cleanup)
@@ -148,6 +153,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(status, "removed")
         self.assertNotIn("model_instructions_file", config_path.read_text(encoding="utf-8"))
 
+    # End-to-end reset removes owned artifacts while retaining a later provider selection.
     def test_full_reset_removes_state_and_prompt_without_reverting_provider(self) -> None:
         temporary_directory, config_path = self.make_config(
             'model_provider = "custom"\nmodel = "gpt-5.5"\n'
@@ -177,6 +183,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertFalse((codex_home / "custom-prompt.md").exists())
         self.assertFalse(codex_instruct.state_file_path(config_path).exists())
 
+    # Editing a CRLF config must not introduce mixed line endings.
     def test_crlf_line_endings_are_preserved(self) -> None:
         text = 'model = "gpt-5.5"\r\n[features]\r\nweb_search = true\r\n'
         updated = codex_instruct.replace_top_level_model_instructions(
@@ -186,6 +193,7 @@ class ManagedConfigTests(unittest.TestCase):
 
         self.assertNotIn("\n", updated.replace("\r\n", ""))
 
+    # An invalid state file cannot nominate config.toml or another non-Markdown file for deletion.
     def test_tampered_state_cannot_nominate_config_for_deletion(self) -> None:
         temporary_directory, config_path = self.make_config(
             'model_instructions_file = "./gpt-5.6-sol-unrestricted-v5.md"\n'
@@ -215,6 +223,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertTrue(config_path.exists())
 
+    # A user-replaced prompt fails the recorded SHA256 check and must be preserved.
     def test_modified_custom_prompt_is_preserved_on_reset(self) -> None:
         temporary_directory, config_path = self.make_config('model = "gpt-5.5"\n')
         self.addCleanup(temporary_directory.cleanup)
@@ -240,6 +249,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(custom_prompt.read_text(encoding="utf-8"), "user replacement\n")
         self.assertIn("./personal.md", config_path.read_text(encoding="utf-8"))
 
+    # Atomic config writes follow a trusted config symlink instead of replacing the link itself.
     def test_atomic_config_update_preserves_symlink(self) -> None:
         temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(temporary_directory.cleanup)
@@ -257,6 +267,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertTrue(config_path.is_symlink())
         self.assertIn("model_instructions_file", target.read_text(encoding="utf-8"))
 
+    # A matching basename outside CODEX_HOME is not treated as a script-owned prompt.
     def test_external_path_with_managed_basename_is_not_owned(self) -> None:
         line = 'model_instructions_file = "/tmp/gpt-5.6-sol-unrestricted-v5.md"'
         self.assertFalse(
@@ -266,6 +277,7 @@ class ManagedConfigTests(unittest.TestCase):
             )
         )
 
+    # Deployment refuses to overwrite a destination that is not already tracked as owned.
     def test_preexisting_unowned_prompt_is_not_overwritten(self) -> None:
         temporary_directory, config_path = self.make_config('model = "gpt-5.5"\n')
         self.addCleanup(temporary_directory.cleanup)
@@ -282,6 +294,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(destination.read_text(encoding="utf-8"), "personal content\n")
         self.assertFalse(codex_instruct.state_file_path(config_path).exists())
 
+    # Full-file recovery remains available only through the explicit snapshot command.
     def test_explicit_snapshot_restore_keeps_manual_recovery(self) -> None:
         temporary_directory, config_path = self.make_config(
             'model_provider = "openai"\n'
@@ -298,6 +311,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertIn('model_provider = "custom"', config_path.read_text(encoding="utf-8"))
 
+    # Legacy deployments preserve prompt files that existed before ownership tracking.
     def test_legacy_preexisting_prompt_is_preserved(self) -> None:
         filename = "gpt-5.6-sol-unrestricted-v5.md"
         temporary_directory, config_path = self.make_config(

--- a/unit_tests/test_codex_instruct.py
+++ b/unit_tests/test_codex_instruct.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import tempfile
-import tomllib
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.8-3.10
+    import tomli as tomllib
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -38,6 +43,7 @@ class ManagedConfigTests(unittest.TestCase):
         codex_instruct.prepare_deployment_state(
             config_path,
             "gpt-5.6-sol-unrestricted-v5.md",
+            "test instructions\n",
         )
         codex_instruct.set_model_instructions(
             config_path,
@@ -72,6 +78,7 @@ class ManagedConfigTests(unittest.TestCase):
         codex_instruct.prepare_deployment_state(
             config_path,
             "gpt-5.6-sol-unrestricted-v35.md",
+            "test instructions\n",
         )
         codex_instruct.set_model_instructions(
             config_path,
@@ -93,6 +100,7 @@ class ManagedConfigTests(unittest.TestCase):
         codex_instruct.prepare_deployment_state(
             config_path,
             "gpt-5.6-sol-unrestricted-v5.md",
+            "test instructions\n",
         )
         codex_instruct.set_model_instructions(
             config_path,
@@ -132,7 +140,7 @@ class ManagedConfigTests(unittest.TestCase):
         self.addCleanup(temporary_directory.cleanup)
         filename = "custom-prompt.md"
 
-        codex_instruct.prepare_deployment_state(config_path, filename)
+        codex_instruct.prepare_deployment_state(config_path, filename, "custom instructions\n")
         codex_instruct.set_model_instructions(config_path, filename)
         changed, status = codex_instruct.restore_managed_model_instructions(config_path)
 
@@ -177,6 +185,142 @@ class ManagedConfigTests(unittest.TestCase):
         )
 
         self.assertNotIn("\n", updated.replace("\r\n", ""))
+
+    def test_tampered_state_cannot_nominate_config_for_deletion(self) -> None:
+        temporary_directory, config_path = self.make_config(
+            'model_instructions_file = "./gpt-5.6-sol-unrestricted-v5.md"\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+        state_path = codex_instruct.state_file_path(config_path)
+        state_path.write_text(
+            json.dumps(
+                {
+                    "version": codex_instruct.STATE_VERSION,
+                    "previous_model_instructions_line": None,
+                    "managed_prompts": {
+                        "config.toml": {
+                            "sha256": "0" * 64,
+                            "existed_before": False,
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(codex_dir=str(config_path.parent), dry_run=False)
+
+        with patch("builtins.input", return_value="y"):
+            result = codex_instruct.reset_managed_install(args)
+
+        self.assertEqual(result, 0)
+        self.assertTrue(config_path.exists())
+
+    def test_modified_custom_prompt_is_preserved_on_reset(self) -> None:
+        temporary_directory, config_path = self.make_config('model = "gpt-5.5"\n')
+        self.addCleanup(temporary_directory.cleanup)
+        codex_home = config_path.parent
+        source = codex_home / "source.md"
+        source.write_text("deployed content\n", encoding="utf-8")
+        args = SimpleNamespace(codex_dir=str(codex_home), dry_run=False)
+        self.assertEqual(
+            codex_instruct.deploy_prompt(args, source, "custom-prompt.md"),
+            0,
+        )
+        custom_prompt = codex_home / "custom-prompt.md"
+        custom_prompt.write_text("user replacement\n", encoding="utf-8")
+        config_path.write_text(
+            'model_instructions_file = "./personal.md"\n',
+            encoding="utf-8",
+        )
+
+        with patch("builtins.input", return_value="y"):
+            result = codex_instruct.reset_managed_install(args)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(custom_prompt.read_text(encoding="utf-8"), "user replacement\n")
+        self.assertIn("./personal.md", config_path.read_text(encoding="utf-8"))
+
+    def test_atomic_config_update_preserves_symlink(self) -> None:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        codex_home = Path(temporary_directory.name)
+        target = codex_home / "shared-config.toml"
+        config_path = codex_home / "config.toml"
+        target.write_text('model = "gpt-5.5"\n', encoding="utf-8")
+        config_path.symlink_to(target.name)
+
+        codex_instruct.set_model_instructions(
+            config_path,
+            "gpt-5.6-sol-unrestricted-v5.md",
+        )
+
+        self.assertTrue(config_path.is_symlink())
+        self.assertIn("model_instructions_file", target.read_text(encoding="utf-8"))
+
+    def test_external_path_with_managed_basename_is_not_owned(self) -> None:
+        line = 'model_instructions_file = "/tmp/gpt-5.6-sol-unrestricted-v5.md"'
+        self.assertFalse(
+            codex_instruct.line_references_managed_prompt(
+                line,
+                codex_instruct.MANAGED_PROMPT_FILENAMES,
+            )
+        )
+
+    def test_preexisting_unowned_prompt_is_not_overwritten(self) -> None:
+        temporary_directory, config_path = self.make_config('model = "gpt-5.5"\n')
+        self.addCleanup(temporary_directory.cleanup)
+        codex_home = config_path.parent
+        source = codex_home / "source.md"
+        source.write_text("new content\n", encoding="utf-8")
+        destination = codex_home / "custom-prompt.md"
+        destination.write_text("personal content\n", encoding="utf-8")
+        args = SimpleNamespace(codex_dir=str(codex_home), dry_run=False)
+
+        result = codex_instruct.deploy_prompt(args, source, destination.name)
+
+        self.assertEqual(result, 2)
+        self.assertEqual(destination.read_text(encoding="utf-8"), "personal content\n")
+        self.assertFalse(codex_instruct.state_file_path(config_path).exists())
+
+    def test_explicit_snapshot_restore_keeps_manual_recovery(self) -> None:
+        temporary_directory, config_path = self.make_config(
+            'model_provider = "openai"\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+        codex_home = config_path.parent
+        snapshot = codex_home / "config.toml.bak_20260723_010203_000001"
+        snapshot.write_text('model_provider = "custom"\n', encoding="utf-8")
+        args = SimpleNamespace(codex_dir=str(codex_home), dry_run=False)
+
+        with patch("builtins.input", return_value="y"):
+            result = codex_instruct.restore_config_snapshot(args, snapshot)
+
+        self.assertEqual(result, 0)
+        self.assertIn('model_provider = "custom"', config_path.read_text(encoding="utf-8"))
+
+    def test_legacy_preexisting_prompt_is_preserved(self) -> None:
+        filename = "gpt-5.6-sol-unrestricted-v5.md"
+        temporary_directory, config_path = self.make_config(
+            f'model_instructions_file = "./{filename}"\n'
+        )
+        self.addCleanup(temporary_directory.cleanup)
+        codex_home = config_path.parent
+        codex_instruct.baseline_backup_path(config_path).write_text(
+            'model = "gpt-5.5"\n',
+            encoding="utf-8",
+        )
+        destination = codex_home / filename
+        destination.write_text("legacy deployment\n", encoding="utf-8")
+        source = codex_home / "source.md"
+        source.write_text("updated deployment\n", encoding="utf-8")
+        args = SimpleNamespace(codex_dir=str(codex_home), dry_run=False)
+
+        self.assertEqual(codex_instruct.deploy_prompt(args, source, filename), 0)
+        with patch("builtins.input", return_value="y"):
+            self.assertEqual(codex_instruct.reset_managed_install(args), 0)
+
+        self.assertTrue(destination.exists())
+        self.assertEqual(destination.read_text(encoding="utf-8"), "updated deployment\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- replace whole-file `config.toml` rollback with field-level ownership of the top-level `model_instructions_file`
- validate the state schema strictly and track managed prompt ownership with SHA256 plus pre-existing-file metadata
- preserve provider, model, authentication, and other CCSwitch changes during ordinary `--reset`
- preserve `config.toml` symlinks and refuse to overwrite unowned Markdown destinations
- add an explicit, confirmed `--restore-snapshot` path for manual full-file emergency recovery
- document CCSwitch-compatible deployment and rollback in both READMEs
- add Python 3.8/3.13 GitHub Actions coverage

## Why

The previous reset flow restored an entire historical `config.toml`. If CCSwitch changed the active Codex provider, model, authentication, or common configuration after prompt deployment, reset could overwrite those newer changes with a stale baseline. The state file also needed stronger validation and file-ownership checks before it could safely nominate prompt files for cleanup.

This change makes the normal reset flow responsible only for the setting and prompt files created by this script. CCSwitch remains authoritative for provider-related configuration. Full snapshot recovery remains available only through an explicit emergency command.

## User impact

After this change, users can:

1. deploy a project prompt,
2. switch Codex providers with CCSwitch,
3. run `python3 codex-instruct.py --reset`,

without reverting the provider selected by CCSwitch. Pre-existing or subsequently modified prompt files are preserved. Existing legacy backups are consulted only for a previous `model_instructions_file`; their other settings are never copied back automatically.

For manual emergency recovery, users can explicitly run:

```bash
python3 codex-instruct.py \
  --restore-snapshot ~/.codex/config.toml.bak_YYYYMMDD_HHMMSS_ffffff \
  --codex-dir ~/.codex
```

## Validation

- Python 3.8: 14 unit tests passed
- Current Python: 14 unit tests passed
- `python -m py_compile codex-instruct.py unit_tests/test_codex_instruct.py`
- `actionlint .github/workflows/test-codex-instruct.yml`
- `git diff --check`

The regression suite covers CCSwitch provider preservation, strict state validation, tampered-state cleanup safety, user-modified and pre-existing prompts, symlinked `config.toml`, external same-basename paths, unowned destination protection, legacy migration, and explicit full-snapshot recovery.
