### PR TITLE
fix: 限流回退导致的 deployment 报错

### DIFF
--- a/.github/scripts/render_star_history.py
+++ b/.github/scripts/render_star_history.py
@@ -19,6 +19,14 @@ DEFAULT_BACKEND_URL = "http://127.0.0.1:8080"
 DEFAULT_REPOSITORY = "mdx-tom/gpt-5.6-instruct"
 THEMES = ("light", "dark")
 
+# The local backend cools a rate-limited token down for 15 minutes, far longer
+# than a job can wait, so retrying the live render is futile; a couple of tries
+# still absorb a transient warm-up blip before failing over to the cached pair.
+LOCAL_RENDER_ATTEMPTS = 2
+# The fallback fetches the last-deployed pair from the Pages CDN, where retries
+# usefully ride out short-lived network hiccups.
+FALLBACK_RENDER_ATTEMPTS = 4
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -89,6 +97,19 @@ def chart_url(backend_url: str, repository: str, theme: str) -> str:
 
 def fallback_chart_url(base_url: str, theme: str) -> str:
     return f"{base_url}/star-history-{theme}.svg"
+
+
+def emit_github_warning(message: str) -> None:
+    """Surface a degraded refresh as a run annotation, not just buried stderr.
+
+    A green job that silently serves a stale chart hides the fact that the live
+    Star History render keeps hitting GitHub rate limits; the annotation makes
+    the degraded state visible so maintainers can rotate or add tokens.
+    """
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return
+    single_line = message.replace("\r", " ").replace("\n", " ")
+    print(f"::warning title=Star History::{single_line}")
 
 
 def download_svg(url: str, attempts: int = 4) -> bytes:
@@ -179,10 +200,11 @@ def fetch_chart_pair(
     *,
     repository: str,
     url_for_theme,
+    attempts: int,
 ) -> Dict[str, bytes]:
     charts = {}
     for theme in THEMES:
-        content = download_svg(url_for_theme(theme))
+        content = download_svg(url_for_theme(theme), attempts=attempts)
         validate_svg(content, repository, theme)
         charts[theme] = content
     return charts
@@ -204,22 +226,25 @@ def main() -> int:
                     repository,
                     theme,
                 ),
+                attempts=LOCAL_RENDER_ATTEMPTS,
             )
         except (RuntimeError, OSError, ValueError, ET.ParseError) as local_error:
             if not args.fallback_base_url:
                 raise
             fallback_base_url = validate_fallback_base_url(args.fallback_base_url)
-            print(
-                "[warning] Local Star History refresh failed; "
-                f"reusing the last deployed chart pair: {local_error}",
-                file=sys.stderr,
+            warning = (
+                "Local Star History refresh failed; reusing the last deployed "
+                f"chart pair: {local_error}"
             )
+            print(f"[warning] {warning}", file=sys.stderr)
+            emit_github_warning(warning)
             charts = fetch_chart_pair(
                 repository=repository,
                 url_for_theme=lambda theme: fallback_chart_url(
                     fallback_base_url,
                     theme,
                 ),
+                attempts=FALLBACK_RENDER_ATTEMPTS,
             )
 
         # Write only after both themes validate, preventing a mixed fresh/stale pair.

--- a/unit-tests/test_star_history_renderer.py
+++ b/unit-tests/test_star_history_renderer.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import io
+import os
 import tempfile
 import threading
 import unittest
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import patch
@@ -102,6 +104,65 @@ class StarHistoryRendererTests(unittest.TestCase):
                 (output_dir / "star-history-dark.svg").read_bytes(),
                 make_svg("dark"),
             )
+
+    # A degraded refresh under Actions must surface a run annotation so a green
+    # job never silently keeps serving a stale chart.
+    def test_rate_limit_emits_github_warning_annotation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_dir = Path(temporary_directory)
+            with serve(FailingBackendHandler) as backend_url, serve(
+                DeployedChartHandler
+            ) as fallback_url:
+                argv = [
+                    "render_star_history.py",
+                    "--backend-url",
+                    backend_url,
+                    "--fallback-base-url",
+                    fallback_url,
+                    "--output-dir",
+                    str(output_dir),
+                ]
+                buffer = io.StringIO()
+                with patch("sys.argv", argv), patch.object(
+                    render_star_history.time,
+                    "sleep",
+                    return_value=None,
+                ), patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}), redirect_stdout(
+                    buffer
+                ):
+                    self.assertEqual(render_star_history.main(), 0)
+
+            self.assertIn("::warning title=Star History::", buffer.getvalue())
+
+    # Outside Actions the annotation is suppressed to keep local output clean.
+    def test_rate_limit_skips_annotation_outside_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_dir = Path(temporary_directory)
+            with serve(FailingBackendHandler) as backend_url, serve(
+                DeployedChartHandler
+            ) as fallback_url:
+                argv = [
+                    "render_star_history.py",
+                    "--backend-url",
+                    backend_url,
+                    "--fallback-base-url",
+                    fallback_url,
+                    "--output-dir",
+                    str(output_dir),
+                ]
+                buffer = io.StringIO()
+                environment = dict(os.environ)
+                environment.pop("GITHUB_ACTIONS", None)
+                with patch("sys.argv", argv), patch.object(
+                    render_star_history.time,
+                    "sleep",
+                    return_value=None,
+                ), patch.dict(os.environ, environment, clear=True), redirect_stdout(
+                    buffer
+                ):
+                    self.assertEqual(render_star_history.main(), 0)
+
+            self.assertNotIn("::warning", buffer.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

`Deploy README and Star History` 部署任务失败（run `30003237663` / `30016645001`）：

```
403 GitHub API rate limit exceeded
Token github_p... rate-limited, cooling down for 15m
503 All GitHub API tokens are rate-limited
[error] Star History rendering failed
```

## 根源

渲染 Star History 需要遍历 stargazers API，本仓库 2.7k+ stars 会以 `Promise.all` 并发发起约 15 个请求，**必然触发 GitHub 二级限流**（403 → token 冷却 15 分钟 → 503）。

也就是说：**"每次靠实时渲染"这条路本身不可靠，回退到上次已部署的图表才是常态路径。** 但当前实现有两个缺陷：

1. 旧工作流只配了 1 个 token（日志 `Usable token amount: 1`），限流后无可用 token，渲染直接硬失败 → 任务变红。
2. 已合入的回退虽让任务变绿，却**慢且不可见**：主渲染对已限流的后端仍无谓重试 4 次（约 12s），且回退后静默长期发布过期图表，Actions 界面看不出降级。

## 修复

1. 拆分重试预算：本地渲染 2 次（吸收预热抖动后快速回退），回退 CDN 抓取保留 4 次。
2. 回退时输出 `::warning::` 注解，使降级在 Actions 界面可见，便于及时轮换/新增 token。
3. 新增单元测试：回退时发注解、非 Actions 环境下抑制注解。

## 验证

```
python3 -m py_compile codex-instruct.py .github/scripts/render_star_history.py unit-tests/*.py
python3 -m unittest discover -s unit-tests   # Ran 18 tests ... OK
```

## 边界

本 PR 只做安全、可测的加固，让回退这条常态路径又快又可见，不改上游 TS。若要让实时渲染真正成功（而非依赖回退），需后续处理：将 stargazers 翻页改为有界并发，或改用 classic PAT / 增加 token 数量。