### PR TITLE
chore: 统一固定依赖并在 CI 增加压缩包校验

### DIFF
--- a/.github/workflows/sync-star-history.yml
+++ b/.github/workflows/sync-star-history.yml
@@ -81,7 +81,7 @@ jobs:
           (cd "${STAR_HISTORY_SOURCE_DIR}/backend" && pnpm install --frozen-lockfile)
 
       - name: Install README renderer
-        run: python3 -m pip install --disable-pip-version-check --no-cache-dir Markdown==3.8.2
+        run: python3 -m pip install --disable-pip-version-check --no-cache-dir ".[pages]"
 
       - name: Render charts and build README pages
         id: render

--- a/.github/workflows/test-codex-instruct.yml
+++ b/.github/workflows/test-codex-instruct.yml
@@ -9,6 +9,7 @@ on:
       - "codex-instruct.py"
       - ".github/scripts/render_star_history.py"
       - "unit-tests/**"
+      - "pyproject.toml"
       - ".github/workflows/test-codex-instruct.yml"
   push:
     branches:
@@ -17,6 +18,7 @@ on:
       - "codex-instruct.py"
       - ".github/scripts/render_star_history.py"
       - "unit-tests/**"
+      - "pyproject.toml"
       - ".github/workflows/test-codex-instruct.yml"
   workflow_dispatch:
 
@@ -43,8 +45,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Python 3.8-3.10 use tomli; newer Python versions use the standard-library tomllib.
-      - name: Install test compatibility dependency
-        run: python -m pip install tomli
+      - name: Install pinned test dependencies
+        run: python -m pip install ".[dev]"
 
       # Catch syntax/import compatibility problems before running behavioral tests.
       - name: Compile deployment script and tests

--- a/.github/workflows/verify-archives.yml
+++ b/.github/workflows/verify-archives.yml
@@ -1,0 +1,42 @@
+# Guard the committed release/history/example/test-script ZIP archives.
+#
+# The plaintext prompt/.py sources are intentionally git-ignored (they contain
+# sensitive text), so content drift can only be checked locally with
+# `python3 sync-archives.py --check` where the sources exist. In CI we instead
+# run the source-free structural check, which confirms every committed archive
+# is a valid single-file ZIP with the expected inner name.
+name: Verify archives
+
+on:
+  pull_request:
+    paths:
+      - "**/*.zip"
+      - "sync-archives.py"
+      - ".github/workflows/verify-archives.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.zip"
+      - "sync-archives.py"
+      - ".github/workflows/verify-archives.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      # Source-free: validates archive structure without the git-ignored sources.
+      - name: Verify committed archives
+        run: python3 sync-archives.py --verify-archives

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ tests/
 releases/
 tmp/
 
+# Build artifacts from `pip install .` (pyproject dependency groups).
+*.egg-info/
+build/
+
 .DS_Store
 **/.DS_Store
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ python3 scripts/run_gpt56_sol_issue_regression.py --dry-run
 gpt-5.6-instruct/
 ├── README.md / README_EN.md           # 中英文首页
 ├── codex-instruct.py                  # v41 默认部署与回滚
-├── sync-archives.py                   # 本地源文件与 ZIP 同步
+├── sync-archives.py                   # 本地源文件与 ZIP 同步 / 结构校验
+├── pyproject.toml                     # 统一的固定版本依赖（dev / pages）
 ├── gpt-5.6-sol-unrestricted-v41.zip   # 唯一默认生产版
 ├── gpt-5.6-sol-unrestricted-v41-skills.zip # 可选 skills 配套包（--file）
 ├── historical-versions/               # v5/v24/v35 复现归档
@@ -226,7 +227,17 @@ gpt-5.6-instruct/
 │   ├── test_codex_instruct.py         # 部署与回滚单元测试
 │   └── test_star_history_renderer.py  # Star History 限流回退测试
 ├── .github/workflows/test-codex-instruct.yml # Python 3.8/3.13 CI
+├── .github/workflows/verify-archives.yml     # ZIP 结构校验 CI
 └── docs/architecture/                 # 可编辑的 Draw.io 架构图源文件
+```
+
+### 依赖
+
+第三方依赖统一固定在 [`pyproject.toml`](pyproject.toml) 中，避免散落在各 workflow 里：
+
+```bash
+pip install ".[dev]"     # 运行单元测试（tomli 仅在 Python < 3.11 安装）
+pip install ".[pages]"   # 构建 GitHub Pages 首页（Markdown==3.8.2）
 ```
 
 ### 维护发布包
@@ -234,8 +245,14 @@ gpt-5.6-instruct/
 默认 `v41`、可选 skills 配套包、历史 `v5/v24/v35` 与测试脚本均由 `sync-archives.py` 统一维护。历史 v24/v35 的本地源证据继续保留在 `reports/prompt_candidates/`，公开目录只提供其 ZIP。修改源文件后，请同步并检查压缩包：
 
 ```bash
-python3 sync-archives.py
-python3 sync-archives.py --check
+python3 sync-archives.py            # 从本地源重新生成 ZIP
+python3 sync-archives.py --check    # 需本地源：逐字节比对 ZIP 与源
+```
+
+本地源为敏感文本、默认 git-ignore，因此 CI 无法运行 `--check`。CI 改跑无需源文件的结构校验，确认每个 ZIP 都是内含单一且命名正确文件的有效压缩包：
+
+```bash
+python3 sync-archives.py --verify-archives
 ```
 
 <a id="upstream-agent-skills"></a>

--- a/README_EN.md
+++ b/README_EN.md
@@ -214,7 +214,8 @@ See [docs/gpt-5.6-sol-safety-eval.md](docs/gpt-5.6-sol-safety-eval.md) for the c
 gpt-5.6-instruct/
 ├── README.md / README_EN.md           # Chinese and English home pages
 ├── codex-instruct.py                  # Default v41 deployment and rollback
-├── sync-archives.py                   # Synchronize local sources and ZIPs
+├── sync-archives.py                   # Sync local sources and ZIPs / structure check
+├── pyproject.toml                     # Unified pinned dependencies (dev / pages)
 ├── gpt-5.6-sol-unrestricted-v41.zip   # Sole default production release
 ├── gpt-5.6-sol-unrestricted-v41-skills.zip # Optional companion (--file)
 ├── historical-versions/               # v5/v24/v35 reproduction archives
@@ -226,7 +227,17 @@ gpt-5.6-instruct/
 │   ├── test_codex_instruct.py         # Deployment and rollback unit tests
 │   └── test_star_history_renderer.py  # Star History rate-limit fallback test
 ├── .github/workflows/test-codex-instruct.yml # Python 3.8/3.13 CI
+├── .github/workflows/verify-archives.yml     # ZIP structure check CI
 └── docs/architecture/                 # Editable Draw.io architecture source
+```
+
+### Dependencies
+
+Third-party dependencies are pinned in one place, [`pyproject.toml`](pyproject.toml), instead of being scattered across workflows:
+
+```bash
+pip install ".[dev]"     # run the unit tests (tomli is installed only on Python < 3.11)
+pip install ".[pages]"   # build the GitHub Pages home page (Markdown==3.8.2)
 ```
 
 ### Maintaining Release Archives
@@ -234,8 +245,14 @@ gpt-5.6-instruct/
 Default `v41`, the optional skills companion, historical `v5/v24/v35`, and test scripts are maintained together by `sync-archives.py`. Local v24/v35 source evidence remains under `reports/prompt_candidates/`, while the public history directory exposes only their ZIP archives. After editing a source, synchronize and verify the archives:
 
 ```bash
-python3 sync-archives.py
-python3 sync-archives.py --check
+python3 sync-archives.py            # regenerate ZIPs from local sources
+python3 sync-archives.py --check    # needs local sources: byte-compare ZIP vs source
+```
+
+The local sources are sensitive text and git-ignored, so CI cannot run `--check`. CI instead runs a source-free structural check confirming every ZIP is a valid single-file archive with the expected inner name:
+
+```bash
+python3 sync-archives.py --verify-archives
 ```
 
 <a id="upstream-agent-skills"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+# Single source of truth for this project's pinned Python dependencies.
+# The runtime scripts (codex-instruct.py, sync-archives.py, the Pages/Star
+# History renderers) rely almost entirely on the standard library; the few
+# third-party pins live here so CI, the deploy workflow, and local runs stay
+# aligned instead of scattering unpinned `pip install` calls across workflows.
+#
+# Install the group you need, for example:
+#   pip install ".[dev]"     # run the unit tests
+#   pip install ".[pages]"   # build the bilingual README Pages site
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gpt-5.6-instruct"
+version = "41.0.0"
+description = "gpt-5.6 破甲提示词及测试包 / jailbreak prompt and test pack"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { file = "LICENSE" }
+
+[project.optional-dependencies]
+# Test/development tooling. tomllib is standard-library from Python 3.11 on,
+# so tomli is only needed on the 3.8-3.10 side of the CI matrix.
+dev = [
+    "tomli==2.2.1 ; python_version < '3.11'",
+]
+# Dependencies for building the GitHub Pages README site.
+pages = [
+    "Markdown==3.8.2",
+]
+
+# The repository is a collection of standalone scripts rather than an importable
+# package, so disable automatic module discovery (hyphenated filenames such as
+# codex-instruct.py are not valid module names). Installing only resolves the
+# dependency groups above.
+[tool.setuptools]
+py-modules = []

--- a/sync-archives.py
+++ b/sync-archives.py
@@ -68,6 +68,58 @@ def archive_specs() -> list[tuple[Path, Path, str]]:
     return prompt_specs + script_specs
 
 
+def expected_archive_contents() -> list[tuple[Path, str]]:
+    """Map every committed archive to the single file it must contain.
+
+    Unlike ``archive_specs``, this needs no local sources, so it can run in a
+    clean CI checkout where the sensitive ``.md``/``scripts/*.py`` sources are
+    git-ignored and absent. Prompt archives use the explicit PROMPT_ARCHIVES
+    mapping; each ``scripts/<name>.zip`` must contain ``<name>.py``.
+    """
+    contents = [
+        (PROJECT_ROOT / destination, archive_name)
+        for _source, destination, archive_name in PROMPT_ARCHIVES
+    ]
+    contents.extend(
+        (archive, f"{archive.stem}.py")
+        for archive in sorted((PROJECT_ROOT / "scripts").glob("*.zip"))
+    )
+    return contents
+
+
+def verify_archive_structure() -> int:
+    """Check that every committed archive is a valid single-file ZIP.
+
+    This guards against corruption, a wrong inner filename, or an accidental
+    multi-file archive. It cannot detect content drift from the local source
+    (that requires the git-ignored sources and is what ``--check`` is for).
+    """
+    failed = False
+    for destination, archive_name in expected_archive_contents():
+        relative = destination.relative_to(PROJECT_ROOT)
+        try:
+            with zipfile.ZipFile(destination) as archive:
+                names = [name for name in archive.namelist() if not name.endswith("/")]
+                ok = names == [archive_name]
+        except FileNotFoundError:
+            print(f"[缺失] {relative}", file=sys.stderr)
+            failed = True
+            continue
+        except zipfile.BadZipFile:
+            print(f"[损坏] {relative}", file=sys.stderr)
+            failed = True
+            continue
+        if ok:
+            print(f"[OK] {relative}")
+        else:
+            print(
+                f"[结构错误] {relative} 应恰好包含 {archive_name}，实际为 {names}",
+                file=sys.stderr,
+            )
+            failed = True
+    return 1 if failed else 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Update release, history, example, and test-script ZIP archives."
@@ -77,7 +129,18 @@ def main() -> int:
         action="store_true",
         help="Verify that every archive exists and exactly matches its local source.",
     )
+    parser.add_argument(
+        "--verify-archives",
+        action="store_true",
+        help=(
+            "Source-free structural check: confirm every committed archive is a "
+            "valid single-file ZIP with the expected inner name. Safe for CI."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.verify_archives:
+        return verify_archive_structure()
 
     specs = archive_specs()
     missing = [source for source, _destination, _name in specs if not source.is_file()]


### PR DESCRIPTION
## 问题

工程化上有两处隐患:

1. **依赖未固定、分散**:`Markdown==3.8.2`、`tomli` 直接散落在各 workflow 的 `pip install` 里,没有统一清单,版本难复现。
2. **ZIP 无守门**:仓库只提交同名 ZIP(明文源刻意 git-ignore),改了本地源忘了同步,ZIP 就会漂移,线上跑旧代码而 CI 无感。

## 背景

按 `.gitignore` 策略,敏感的明文 prompt(`.md`)与测试脚本(`scripts/*.py`)**故意不提交**,仓库只发布同名 ZIP,由 `sync-archives.py` 保持同步。因此"源"在干净 checkout 中并不存在。

## 关键约束

`sync-archives.py --check` 做的是"ZIP 逐字节比对本地源",**必须有源**。而 CI 的干净 checkout 没有源(git-ignored),直接跑 `--check` 会因"缺少源文件"退出码 2,**必然失败**。所以内容漂移只能在有源的维护者本地/pre-commit 校验,公开 CI 做不到。

## 修复

1. **统一固定依赖**:新增 `pyproject.toml`,用 optional-dependencies 分组固定版本:
   - `dev`:`tomli==2.2.1 ; python_version < '3.11'`(3.11+ 用标准库 tomllib)
   - `pages`:`Markdown==3.8.2`
   - 安装:`pip install ".[dev]"` / `pip install ".[pages]"`
2. **CI 增加压缩包校验**:新增 `sync-archives.py --verify-archives`——**无需源**的结构校验,确认每个committed ZIP 都是"有效、单文件、内层文件名正确"的压缩包(可查出损坏/错名/多文件,查不出内容漂移);新增 `verify-archives.yml`,在 ZIP 或 `sync-archives.py` 变更时触发。
3. **接线**:`test-codex-instruct` 改用 `pip install ".[dev]"`,部署 workflow 改用 `".[pages]"`;忽略 pip 构建产物;两个 README 补充依赖与校验命令。
4. `--check`(需源)保留给维护者本地/pre-commit 使用。

## 验证

在干净 venv(等价 CI)中:

```
python3 -m venv /tmp/venv && /tmp/venv/bin/pip install ".[dev]"     # tomli 在 3.11+ 正确跳过
/tmp/venv/bin/pip install ".[pages]"                               # Markdown 3.8.2
python3 -m py_compile codex-instruct.py sync-archives.py .github/scripts/*.py unit-tests/*.py
python3 -m unittest discover -s unit-tests -q                       # Ran 16 tests ... OK
python3 sync-archives.py --verify-archives                          # 27 个 ZIP 全部 [OK], exit 0
```

## 说明

ZIP 打包策略本身不动(那是刻意的敏感内容策略)。本 PR 只补齐依赖固定与公开侧可行的 ZIP 守门,不触碰明文源。