### PR TITLE
fix Windows atomic write newline handling

### DIFF
--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -256,7 +256,9 @@ def atomic_write_text(path: Path, text: str, *, follow_symlink: bool = False) ->
     )
     temporary_path = Path(temporary_name)
     try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        # Disable platform newline translation so the deployed file hash matches
+        # the SHA256 stored in the managed-install state on Windows as well.
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())

--- a/unit-tests/test_codex_instruct.py
+++ b/unit-tests/test_codex_instruct.py
@@ -31,6 +31,15 @@ class ManagedConfigTests(unittest.TestCase):
         config_path.write_text(text, encoding="utf-8")
         return temporary_directory, config_path
 
+    def test_atomic_write_preserves_lf_bytes_on_windows(self) -> None:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        path = Path(temporary_directory.name) / "prompt.md"
+
+        codex_instruct.atomic_write_text(path, "first\nsecond\n")
+
+        self.assertEqual(path.read_bytes(), b"first\nsecond\n")
+
     def test_v42_is_the_only_default_release(self) -> None:
         self.assertEqual(
             codex_instruct.DEFAULT_PROMPT_MD_FILENAME,
@@ -231,7 +240,12 @@ class ManagedConfigTests(unittest.TestCase):
         target = codex_home / "shared-config.toml"
         config_path = codex_home / "config.toml"
         target.write_text('model = "gpt-5.5"\n', encoding="utf-8")
-        config_path.symlink_to(target.name)
+        try:
+            config_path.symlink_to(target.name)
+        except OSError as exc:
+            if getattr(exc, "winerror", None) == 1314:
+                self.skipTest("Windows symlink privilege is unavailable")
+            raise
 
         codex_instruct.set_model_instructions(
             config_path,


### PR DESCRIPTION
## Summary
- disable implicit LF-to-CRLF translation in atomic text writes
- keep deployed prompt bytes aligned with the SHA256 recorded in managed-install state
- add a focused byte-level regression test and skip the symlink test when Windows lacks symlink privilege

## Validation
- `python -m unittest discover -s unit-tests -p "test_*.py"` (25 passed, 1 skipped)