### PR TITLE
docs: refine README release table, emoji, and declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@
 
 当前唯一生产版本为 `v42`，可通过 `codex-instruct.py` 预览、部署和回滚。历史 `v5`、`v24`、`v35`、`v41` 及 `v41-skills` 均已移入 [`historical-versions/`](historical-versions/) 用于复现。
 
-**声明：** 本项目不会用于任何商业化行为，包括但不限于创业融资宣传、技术授权转让和付费技术服务。本项目旨在提升 AI 安全。未来无论项目获得多少关注，我们都将保持初心，共同筑牢 AI 的安全边界。
+**声明 ⚠️：** 本项目不会用于任何商业化行为，包括但不限于创业融资宣传、技术授权转让和付费技术服务。本项目旨在提升 AI 安全。未来无论项目获得多少关注，我们都将保持初心，共同筑牢 AI 的安全边界。本项目使用 Codex 官方配置机制，不修改二进制、不劫持网络、不篡改进程。请仅在你有权操作的环境中使用，并自行承担使用风险。
 
 <a id="architecture"></a>
 
-## 系统架构
+## 系统架构 🏗️
 
 <p align="center">
   <picture>
@@ -52,11 +52,11 @@
 
 <a id="versions"></a>
 
-## 默认版本
+## 默认版本 📦
 
-| 版本 | 定位 | 生产入口 | 获取 |
+| 版本 | 定位 | 入口 | 获取 |
 |---|---|---|---|
-| **v42（唯一默认版）** | 跨域路由、状态连续性、首轮执行、工件验证与可回滚交付 | `python3 codex-instruct.py --apply` | [ZIP](gpt-5.6-sol-unrestricted-v42.zip) |
+| **v42** | 唯一生产版 | `python3 codex-instruct.py --apply` | [ZIP](gpt-5.6-sol-unrestricted-v42.zip) |
 
 当前发布 ZIP 的 SHA256：
 
@@ -66,7 +66,7 @@ v42  11f0515be89943a7244d07b625a497b04dde07a51ba26e41df583a0acc145a09
 
 <a id="quick-start"></a>
 
-## 快速开始
+## 快速开始 🚀
 
 ### 1. 获取项目
 
@@ -139,7 +139,7 @@ model_instructions_file = "./gpt-5.6-sol-unrestricted-v42.md"
 
 <a id="results"></a>
 
-## 评测结果
+## 评测结果 📊
 
 v42 发布门禁中，Issues #5/#22 的两个无历史对话原始输入在 `medium` 推理下一次通过 **2/2 cases、2/2 turns、2/2 artifact gates**，无需重复输入。扩展专项集在 `low` 下达到 **60/60 cases、68/68 turns、8/8 artifact gates**；原 120 条 `medium` 测试集在 `low` 下首跑 115/120，定向审计 5/5 后形成保留替换来源的 120/120 汇总。
 
@@ -172,7 +172,7 @@ v42 发布门禁中，Issues #5/#22 的两个无历史对话原始输入在 `med
 
 </details>
 
-## 评测工具
+## 评测工具 🧪
 
 项目提供本地评测脚本，用于生成提示词库、运行回归并离线校验评分逻辑。测试数据、运行日志和详细方法说明不在 README 展开，参见 [中文对比测试文档](docs/comparison-tests.md) 与 [English Documentation](docs/comparison-tests-en.md)。
 
@@ -193,7 +193,7 @@ python3 scripts/verify_gpt56_sol_regression_scoring.py
 
 <a id="layout"></a>
 
-## 项目结构
+## 项目结构 🗂️
 
 ```text
 gpt-5.6-instruct/
@@ -219,15 +219,11 @@ python3 sync-archives.py --check
 
 同步器会跳过内容已经匹配的 ZIP，避免仅因时间戳或压缩元数据变化而改变既有发布包字节。
 
-## 声明
-
-本项目使用 Codex 官方配置机制，不修改二进制、不劫持网络、不篡改进程。请仅在你有权操作的环境中使用，并自行承担使用风险。
-
-## License
+## 许可证 📄
 
 本项目采用 [MIT License](LICENSE)。
 
-## Star History
+## Star History ⭐
 
 <p align="center">
   <a href="https://www.star-history.com/?repos=MDX-Tom%2Fgpt-5.6-instruct&type=date&legend=top-left">
@@ -239,7 +235,7 @@ python3 sync-archives.py --check
   </a>
 </p>
 
-## 致谢
+## 致谢 🙏
 
 参考并延展自 [yynxxxxx/Codex-5.5-codex-instruct-5.5](https://github.com/yynxxxxx/Codex-5.5-codex-instruct-5.5)。感谢 [yynxxxxx](https://github.com/yynxxxxx) / li lingbo 的开源工作。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,11 +34,11 @@ The project's latest iteration is `v42`. During optimization of a new release, t
 
 The sole production release is `v42`, which `codex-instruct.py` can preview, deploy, and roll back. Historical `v5`, `v24`, `v35`, `v41`, and `v41-skills` releases have moved to [`historical-versions/`](historical-versions/) for reproduction.
 
-**Statement:** This project will not be used for any commercial activity, including but not limited to startup fundraising promotion, technology licensing or transfer, and paid technical services. Its purpose is to advance AI safety. Regardless of how much attention the project may receive in the future, we will remain true to this mission and work together to strengthen the safety boundaries of AI.
+**Statement ⚠️:** This project will not be used for any commercial activity, including but not limited to startup fundraising promotion, technology licensing or transfer, and paid technical services. Its purpose is to advance AI safety. Regardless of how much attention the project may receive in the future, we will remain true to this mission and work together to strengthen the safety boundaries of AI. This project uses the official Codex configuration mechanism; it does not modify binaries, intercept network traffic, or tamper with processes. Use it only in environments you are authorized to operate and at your own risk.
 
 <a id="architecture"></a>
 
-## System Architecture
+## System Architecture 🏗️
 
 <p align="center">
   <picture>
@@ -52,11 +52,11 @@ The architecture consists of iterative optimization and production use. During i
 
 <a id="versions"></a>
 
-## Default Release
+## Default Release 📦
 
-| Release | Focus | Production entry | Download |
+| Release | Role | Entry | Download |
 |---|---|---|---|
-| **v42 (sole default)** | Cross-domain routing, state continuity, first-turn execution, artifact verification, and rollback-ready delivery | `python3 codex-instruct.py --apply` | [ZIP](gpt-5.6-sol-unrestricted-v42.zip) |
+| **v42** | Sole production release | `python3 codex-instruct.py --apply` | [ZIP](gpt-5.6-sol-unrestricted-v42.zip) |
 
 Current release-ZIP SHA256:
 
@@ -66,7 +66,7 @@ v42  11f0515be89943a7244d07b625a497b04dde07a51ba26e41df583a0acc145a09
 
 <a id="quick-start"></a>
 
-## Quick Start
+## Quick Start 🚀
 
 ### 1. Get the project
 
@@ -139,7 +139,7 @@ To roll back manually, delete or comment out the line above with `#` to restore 
 
 <a id="results"></a>
 
-## Evaluation Results
+## Evaluation Results 📊
 
 In the v42 release gates, the two zero-history original inputs for Issues #5/#22 pass on their first attempt at `medium` reasoning with **2/2 cases, 2/2 turns, and 2/2 artifact gates**, without repeated input. The expanded targeted set reaches **60/60 cases, 68/68 turns, and 8/8 artifact gates** at `low`. On the original 120-case `medium` set at `low`, the first pass is 115/120; a targeted 5/5 audit then produces a provenance-preserving 120/120 aggregate.
 
@@ -172,7 +172,7 @@ The charts preserve comparable historical data through v41. They do not append v
 
 </details>
 
-## Evaluation Toolkit
+## Evaluation Toolkit 🧪
 
 The project includes local tools for generating prompt banks, running regressions, and validating scoring logic offline. README does not duplicate test data, run logs, or detailed methodology; see the [English comparison-test documentation](docs/comparison-tests-en.md) and [中文对比测试文档](docs/comparison-tests.md) for details.
 
@@ -193,7 +193,7 @@ python3 scripts/verify_gpt56_sol_regression_scoring.py
 
 <a id="layout"></a>
 
-## Project Layout
+## Project Layout 🗂️
 
 ```text
 gpt-5.6-instruct/
@@ -219,15 +219,11 @@ python3 sync-archives.py --check
 
 The synchronizer skips ZIPs whose member content already matches, preventing timestamp or compression metadata alone from changing established release bytes.
 
-## Disclaimer
-
-This project uses the official Codex configuration mechanism. It does not modify binaries, intercept network traffic, or tamper with processes. Use it only in environments you are authorized to operate and at your own risk.
-
-## License
+## License 📄
 
 This project is released under the [MIT License](LICENSE).
 
-## Star History
+## Star History ⭐
 
 <p align="center">
   <a href="https://www.star-history.com/?repos=MDX-Tom%2Fgpt-5.6-instruct&type=date&legend=top-left">
@@ -239,7 +235,7 @@ This project is released under the [MIT License](LICENSE).
   </a>
 </p>
 
-## Acknowledgements
+## Acknowledgements 🙏
 
 This project is based on and extends [yynxxxxx/Codex-5.5-codex-instruct-5.5](https://github.com/yynxxxxx/Codex-5.5-codex-instruct-5.5). Thanks to the authors, [yynxxxxx](https://github.com/yynxxxxx) and li lingbo, for their open-source work.
 


### PR DESCRIPTION
## What changed

- Condense the Chinese and English default-release tables to a single concise v42 row.
- Add semantic emoji to major README sections for easier scanning.
- Merge the technical-use disclaimer into the non-commercial AI-safety statement and remove the duplicate bottom section.

## Validation

- Built the Pages README output with `.github/scripts/build_pages_readme.py`.
- Passed `git diff --check`.

This PR updates the README presentation without changing release artifacts or runtime behavior.